### PR TITLE
chore: update example pynumaflow version

### DIFF
--- a/examples/developer_guide/pipeline-numaflow.yaml
+++ b/examples/developer_guide/pipeline-numaflow.yaml
@@ -10,15 +10,20 @@ spec:
         generator:
           rpu: 10
           duration: 1s
+    - name: flatmap
+      udf:
+        container:
+          # split the incoming message by comma
+          image: quay.io/numaio/numaflow-python/map-flatmap:latest
     - name: cat
       udf:
         container:
-          # compute the sum
+          # simply forward the message
           image: quay.io/numaio/numaflow-python/map-forward-message:latest
     - name: counter
       udf:
         container:
-          # compute the sum
+          # count the number of incoming messages
           image: quay.io/numaio/numaflow-python/reduce-counter:latest
         groupBy:
           window:
@@ -34,6 +39,8 @@ spec:
             image: quay.io/numaio/numaflow-python/sink-log:latest
   edges:
     - from: in
+      to: flatmap
+    - from: flatmap
       to: cat
     - from: cat
       to: counter

--- a/examples/function/counter/pyproject.toml
+++ b/examples/function/counter/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.3.0"
+pynumaflow = "~0.3.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/examples/function/flatmap/pyproject.toml
+++ b/examples/function/flatmap/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.3.0"
+pynumaflow = "~0.3.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/examples/function/forward_message/pyproject.toml
+++ b/examples/function/forward_message/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.3.0"
+pynumaflow = "~0.3.2"
 
 [tool.poetry.dev-dependencies]
 

--- a/examples/sink/log/pyproject.toml
+++ b/examples/sink/log/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.3.0"
+pynumaflow = "~0.3.2"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
example images built, tested, and pushed.

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/19543684/209017270-bfde90f6-6c26-4b21-9c33-e0fa8b9c9786.png">


```yaml
apiVersion: numaflow.numaproj.io/v1alpha1
kind: Pipeline
metadata:
  name: pynumasdk
spec:
  vertices:
    - name: in
      source:
        # A self data generating source
        generator:
          rpu: 10
          duration: 1s
    - name: flatmap
      udf:
        container:
          image: quay.io/numaio/numaflow-python/map-flatmap:latest
    - name: cat
      udf:
        container:
          image: quay.io/numaio/numaflow-python/map-forward-message:latest
    - name: counter
      udf:
        container:
          image: quay.io/numaio/numaflow-python/reduce-counter:latest
        groupBy:
          window:
            fixed:
              length: 10s
          keyed: true
    - name: sink
      scale:
        min: 1
      sink:
        udsink:
          container:
            image: quay.io/numaio/numaflow-python/sink-log:latest
  edges:
    - from: in
      to: flatmap
    - from: flatmap
      to: cat
    - from: cat
      to: counter
      parallelism: 1
    - from: counter
      to: sink
```
