### PR TITLE
fix: store strong references of task objects 

### DIFF
--- a/examples/function/asyncio-reduce/README.md
+++ b/examples/function/asyncio-reduce/README.md
@@ -29,6 +29,26 @@ async def reduce_handler(key: str, datums: AsyncIterable[Datum], md: Metadata) -
     ...
 ```
 
+
+
+**Note**: If using the ```create_task``` ([Refer here](https://docs.python.org/3/library/asyncio-task.html#creating-tasks))  method for creating coroutines,
+It is important to save a reference to the result of this function, 
+to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks.
+A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done.
+For reliable background tasks, gather them in a collection:
+
+
+```python
+running_tasks = set()
+# [...]
+task = asyncio.create_task(some_background_function())
+running_tasks.add(task)
+task.add_done_callback(lambda t: running_tasks.remove(t))
+```
+
+
+
+
 **To compare the performance of the Async and the sequential implementation, we run and compare the results
 on the following scenarios on an HTTP server.**
 

--- a/pynumaflow/function/server.py
+++ b/pynumaflow/function/server.py
@@ -221,10 +221,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
             self.__async_reduce_handler(interval_window, request_iterator)
         )
 
-        # Save a reference to the result of this function, to avoid a task disappearing mid-execution.
-        # The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere
-        # may get garbage collected at any time, even before it’s done. Adding a callback to remove the task
-        # when its completed.
+        # Save a reference to the result of this function, to avoid a
+        # task disappearing mid-execution.
         self.background_tasks.add(response_task)
         response_task.add_done_callback(lambda t: self.background_tasks.remove(t))
 
@@ -250,6 +248,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
                 task = asyncio.create_task(
                     self.__invoke_reduce(key, riter, Metadata(interval_window=interval_window))
                 )
+                # Save a reference to the result of this function, to avoid a
+                # task disappearing mid-execution.
                 self.background_tasks.add(task)
                 task.add_done_callback(lambda t: self.background_tasks.remove(t))
                 result = ReduceResult(task, niter, key)

--- a/pynumaflow/function/server.py
+++ b/pynumaflow/function/server.py
@@ -109,6 +109,9 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
         self._max_message_size = max_message_size
         self._max_threads = max_threads
         self.cleanup_coroutines = []
+        # Collection for storing strong references to all running tasks.
+        # Event loop only keeps a weak reference, which can cause it to
+        # get lost during execution.
         self.background_tasks = set()
 
         self._server_options = [

--- a/pynumaflow/function/server.py
+++ b/pynumaflow/function/server.py
@@ -220,6 +220,11 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
         response_task = asyncio.create_task(
             self.__async_reduce_handler(interval_window, request_iterator)
         )
+
+        # Save a reference to the result of this function, to avoid a task disappearing mid-execution.
+        # The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere
+        # may get garbage collected at any time, even before it’s done. Adding a callback to remove the task
+        # when its completed.
         self.background_tasks.add(response_task)
         response_task.add_done_callback(lambda t: self.background_tasks.remove(t))
 

--- a/pynumaflow/function/server.py
+++ b/pynumaflow/function/server.py
@@ -109,6 +109,7 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
         self._max_message_size = max_message_size
         self._max_threads = max_threads
         self.cleanup_coroutines = []
+        self.background_tasks = set()
 
         self._server_options = [
             ("grpc.max_send_message_length", self._max_message_size),
@@ -219,6 +220,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
         response_task = asyncio.create_task(
             self.__async_reduce_handler(interval_window, request_iterator)
         )
+        self.background_tasks.add(response_task)
+        response_task.add_done_callback(lambda t: self.background_tasks.remove(t))
 
         await response_task
         results_futures = response_task.result()
@@ -242,6 +245,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
                 task = asyncio.create_task(
                     self.__invoke_reduce(key, riter, Metadata(interval_window=interval_window))
                 )
+                self.background_tasks.add(task)
+                task.add_done_callback(lambda t: self.background_tasks.remove(t))
                 result = ReduceResult(task, niter, key)
 
                 callable_dict[key] = result


### PR DESCRIPTION
Fixes #63 
Save strong references of tasks/futures so that they are not lost mid execution due to GC. 