### PR TITLE
chore: re-raise UDFError instead of dropping messages

### DIFF
--- a/pynumaflow/function/server.py
+++ b/pynumaflow/function/server.py
@@ -142,10 +142,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
                 ),
             )
         except Exception as err:
-            _LOGGER.critical("UDFError, dropping message on the floor: %r", err, exc_info=True)
-
-            # a neat hack to drop
-            msgs = Messages.as_forward_all(None)
+            _LOGGER.critical("UDFError, re-raising the error: %r", err, exc_info=True)
+            raise err
 
         datums = []
         for msg in msgs.items():
@@ -176,9 +174,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
                 ),
             )
         except Exception as err:
-            _LOGGER.critical("UDFError, dropping message on the floor: %r", err, exc_info=True)
-            # a neat hack to drop
-            msgts = MessageTs.as_forward_all(None, None)
+            _LOGGER.critical("UDFError, re-raising the error: %r", err, exc_info=True)
+            raise err
 
         datums = []
         for msgt in msgts.items():
@@ -275,10 +272,8 @@ class UserDefinedFunctionServicer(udfunction_pb2_grpc.UserDefinedFunctionService
         try:
             msgs = await self.__reduce_handler(key, request_iterator, md)
         except Exception as err:
-            _LOGGER.critical("UDFError, dropping message on the floor: %r", err, exc_info=True)
-
-            # a neat hack to drop
-            msgs = Messages.as_forward_all(None)
+            _LOGGER.critical("UDFError, re-raising the error: %r", err, exc_info=True)
+            raise err
 
         datums = []
         for msg in msgs.items():

--- a/pynumaflow/tests/function/test_async_server.py
+++ b/pynumaflow/tests/function/test_async_server.py
@@ -192,6 +192,24 @@ class TestAsyncServer(unittest.TestCase):
             response.elements[0].value,
         )
 
+    def test_reduce_invalid_metadata(self) -> None:
+        stub = self.__stub()
+        request, metadata = start_reduce_streaming_request()
+        invalid_metadata = (
+            (DATUM_KEY, "test"),
+        )
+        try:
+            generator_response = stub.ReduceFn(
+                request_iterator=request_generator(count=10, request=request), metadata=invalid_metadata
+            )
+            count = 0
+            for _ in generator_response:
+                count += 1
+        except Exception as err:
+            self.assertTrue("Expected to have all key/window_start_time/window_end_time" in err.__str__())
+            return
+        self.fail("Expected an exception.")
+
     def test_reduce(self) -> None:
         stub = self.__stub()
         request, metadata = start_reduce_streaming_request()

--- a/pynumaflow/tests/function/test_async_server.py
+++ b/pynumaflow/tests/function/test_async_server.py
@@ -195,18 +195,19 @@ class TestAsyncServer(unittest.TestCase):
     def test_reduce_invalid_metadata(self) -> None:
         stub = self.__stub()
         request, metadata = start_reduce_streaming_request()
-        invalid_metadata = (
-            (DATUM_KEY, "test"),
-        )
+        invalid_metadata = ((DATUM_KEY, "test"),)
         try:
             generator_response = stub.ReduceFn(
-                request_iterator=request_generator(count=10, request=request), metadata=invalid_metadata
+                request_iterator=request_generator(count=10, request=request),
+                metadata=invalid_metadata,
             )
             count = 0
             for _ in generator_response:
                 count += 1
         except Exception as err:
-            self.assertTrue("Expected to have all key/window_start_time/window_end_time" in err.__str__())
+            self.assertTrue(
+                "Expected to have all key/window_start_time/window_end_time" in err.__str__()
+            )
             return
         self.fail("Expected an exception.")
 

--- a/pynumaflow/tests/function/test_async_server_err.py
+++ b/pynumaflow/tests/function/test_async_server_err.py
@@ -26,6 +26,7 @@ from pynumaflow.tests.function.test_server import (
 LOGGER = setup_logging(__name__)
 
 
+# This handler mimics the scenario where reduce UDF throws a runtime error.
 async def err_async_reduce_handler(
     key: str, datums: AsyncIterable[Datum], md: Metadata
 ) -> Messages:
@@ -97,7 +98,7 @@ async def start_server():
     await server.wait_for_termination()
 
 
-class TestAsyncServer(unittest.TestCase):
+class TestAsyncServerErrorScenario(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         global _loop

--- a/pynumaflow/tests/function/test_async_server_err.py
+++ b/pynumaflow/tests/function/test_async_server_err.py
@@ -1,0 +1,149 @@
+import asyncio
+import logging
+import threading
+import unittest
+from typing import AsyncIterable
+
+import grpc
+
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
+from grpc.aio._server import Server
+
+from pynumaflow import setup_logging
+from pynumaflow._constants import DATUM_KEY, WIN_START_TIME, WIN_END_TIME
+from pynumaflow.function import Messages, Message, Datum, Metadata, UserDefinedFunctionServicer
+from pynumaflow.function.proto import udfunction_pb2, udfunction_pb2_grpc
+from pynumaflow.tests.function.test_server import (
+    mapt_handler,
+    map_handler,
+    mock_event_time,
+    mock_watermark,
+    mock_message,
+    mock_interval_window_start,
+    mock_interval_window_end,
+)
+
+LOGGER = setup_logging(__name__)
+
+
+async def err_async_reduce_handler(key: str, datums: AsyncIterable[Datum], md: Metadata) -> Messages:
+    interval_window = md.interval_window
+    counter = 0
+    async for _ in datums:
+        counter += 1
+        raise RuntimeError("Got a runtime error from reduce handler.")
+
+    msg = (
+        f"counter:{counter} interval_window_start:{interval_window.start} "
+        f"interval_window_end:{interval_window.end}"
+    )
+
+    return Messages(Message.to_vtx(key, str.encode(msg)))
+
+
+def request_generator(count, request, resetkey: bool = False):
+    for i in range(count):
+        if resetkey:
+            request.key = f"key-{i}"
+        yield request
+
+
+def start_reduce_streaming_request() -> (Datum, tuple):
+    event_time_timestamp = _timestamp_pb2.Timestamp()
+    event_time_timestamp.FromDatetime(dt=mock_event_time())
+    watermark_timestamp = _timestamp_pb2.Timestamp()
+    watermark_timestamp.FromDatetime(dt=mock_watermark())
+
+    request = udfunction_pb2.Datum(
+        value=mock_message(),
+        event_time=udfunction_pb2.EventTime(event_time=event_time_timestamp),
+        watermark=udfunction_pb2.Watermark(watermark=watermark_timestamp),
+    )
+
+    metadata = (
+        (DATUM_KEY, "test"),
+        (WIN_START_TIME, f"{mock_interval_window_start()}"),
+        (WIN_END_TIME, f"{mock_interval_window_end()}"),
+    )
+    return request, metadata
+
+
+_s: Server = None
+_channel = grpc.insecure_channel("localhost:50052")
+_loop = None
+
+
+def startup_callable(loop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+async def start_server():
+    server = grpc.aio.server()
+    udfs = UserDefinedFunctionServicer(
+        reduce_handler=err_async_reduce_handler,
+        map_handler=map_handler,
+        mapt_handler=mapt_handler,
+    )
+    udfunction_pb2_grpc.add_UserDefinedFunctionServicer_to_server(udfs, server)
+    listen_addr = "[::]:50052"
+    server.add_insecure_port(listen_addr)
+    logging.info("Starting server on %s", listen_addr)
+    global _s
+    _s = server
+    await server.start()
+    await server.wait_for_termination()
+
+
+class TestAsyncServer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        global _loop
+        loop = asyncio.new_event_loop()
+        _loop = loop
+        _thread = threading.Thread(target=startup_callable, args=(loop,), daemon=True)
+        _thread.start()
+        asyncio.run_coroutine_threadsafe(start_server(), loop=loop)
+        while True:
+            try:
+                with grpc.insecure_channel("localhost:50052") as channel:
+                    f = grpc.channel_ready_future(channel)
+                    f.result(timeout=10)
+                    if f.done():
+                        break
+            except grpc.FutureTimeoutError as e:
+                LOGGER.error("error trying to connect to grpc server")
+                LOGGER.error(e)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            _loop.stop()
+            LOGGER.info("stopped the event loop")
+        except Exception as e:
+            LOGGER.error(e)
+
+    def test_reduce_error(self) -> None:
+        stub = self.__stub()
+        request, metadata = start_reduce_streaming_request()
+        try:
+            generator_response = stub.ReduceFn(
+                request_iterator=request_generator(count=10, request=request), metadata=metadata
+            )
+            count = 0
+            for _ in generator_response:
+                count += 1
+        except Exception as err:
+            self.assertTrue(
+                "Got a runtime error from reduce handler." in err.__str__()
+            )
+            return
+        self.fail("Expected an exception.")
+
+    def __stub(self):
+        return udfunction_pb2_grpc.UserDefinedFunctionStub(_channel)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/pynumaflow/tests/function/test_async_server_err.py
+++ b/pynumaflow/tests/function/test_async_server_err.py
@@ -26,7 +26,9 @@ from pynumaflow.tests.function.test_server import (
 LOGGER = setup_logging(__name__)
 
 
-async def err_async_reduce_handler(key: str, datums: AsyncIterable[Datum], md: Metadata) -> Messages:
+async def err_async_reduce_handler(
+    key: str, datums: AsyncIterable[Datum], md: Metadata
+) -> Messages:
     interval_window = md.interval_window
     counter = 0
     async for _ in datums:
@@ -134,9 +136,7 @@ class TestAsyncServer(unittest.TestCase):
             for _ in generator_response:
                 count += 1
         except Exception as err:
-            self.assertTrue(
-                "Got a runtime error from reduce handler." in err.__str__()
-            )
+            self.assertTrue("Got a runtime error from reduce handler." in err.__str__())
             return
         self.fail("Expected an exception.")
 

--- a/pynumaflow/tests/function/test_server.py
+++ b/pynumaflow/tests/function/test_server.py
@@ -283,5 +283,6 @@ class TestServer(unittest.TestCase):
         with self.assertRaises(ValueError):
             UserDefinedFunctionServicer()
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
closes #68 

Manual E2E Testing Notes:

After this change, if UDF throws an exception, the exception immediately get re-raised and Numaflow will keep retrying on failed messages until the exception gets resolved. In my test, since the exception never gets resolved, the retry keeps going on forever.

UDF numa log
```
ERROR 2023-03-30 15:03:46 {"level":"error","ts":1680203026.7438965,"logger":"numaflow.MapUDF-processor","caller":"forward/forward.go:561","msg":"UDF.Apply error","vertex":"err-test-throw-error","protocol":"uds-grpc-map-udf","error":"gRPC client.MapFn failed, failed to execute c.grpcClt.MapFn(): rpc error: code = Unknown desc = Exception calling application: Sorry, raising an exception","stacktrace":"github.com/numaproj/numaflow/pkg/forward.(*InterStepDataForward).applyUDF\n\t/Users/kyang5/Desktop/development/numaflow/numaflow/pkg/forward/forward.go:561\ngithub.com/numaproj/numaflow/pkg/forward.(*InterStepDataForward).concurrentApplyUDF\n\t/Users/kyang5/Desktop/development/numaflow/numaflow/pkg/forward/forward.go:546\ngithub.com/numaproj/numaflow/pkg/forward.(*InterStepDataForward).forwardAChunk.func1\n\t/Users/kyang5/Desktop/development/numaflow/numaflow/pkg/forward/forward.go:264"}
ERROR 2023-03-30 15:03:46 {"level":"error","ts":1680203026.7438965,"logger":"numaflow.MapUDF-processor","caller":"forward/forward.go:561","msg":"UDF.Apply error","vertex":"err-test-throw-error","protocol":"uds-grpc-map-udf","error":"gRPC client.MapFn failed, failed to execute c.grpcClt.MapFn(): rpc error: code = Unknown desc = Exception calling application: Sorry, raising an exception","stacktrace":"github.com/numaproj/numaflow/pkg/forward.(*InterStepDataForward).applyUDF\n\t/Users/kyang5/Desktop/development/numaflow/numaflow/pkg/forward/forward.go:561\ngithub.com/numaproj/numaflow/pkg/forward.(*InterStepDataForward).concurrentApplyUDF\n\t/Users/kyang5/Desktop/development/numaflow/numaflow/pkg/forward/forward.go:546\ngithub.com/numaproj/numaflow/pkg/forward.(*InterStepDataForward).forwardAChunk.func1\n\t/Users/kyang5/Desktop/development/numaflow/numaflow/pkg/forward/forward.go:264"}
...
...
```

UDF udf log

```
2023-03-30 19:04:18 CRITICAL UDFError, re-raising the error: Exception('Sorry, raising an exception')
Exception: Sorry, raising an exception
raise Exception("Sorry, raising an exception")
File "/app/example.py", line 10, in my_handler
msgs = self.__map_handler(
File "/opt/pysetup/.venv/lib/python3.10/site-packages/pynumaflow/function/server.py", line 135, in MapFn
Traceback (most recent call last):
2023-03-30 19:04:18 CRITICAL UDFError, re-raising the error: Exception('Sorry, raising an exception')
Exception: Sorry, raising an exception
raise Exception("Sorry, raising an exception")
File "/app/example.py", line 10, in my_handler
msgs = self.__map_handler(
File "/opt/pysetup/.venv/lib/python3.10/site-packages/pynumaflow/function/server.py", line 135, in MapFn
Traceback (most recent call last):
...
...
```

I sent two messages using HTTP. Messages stay in Pending status.
![Screenshot 2023-03-30 at 3 11 39 PM](https://user-images.githubusercontent.com/13165977/228958751-7ceb6be0-2c65-48b3-91a1-687961a7738f.png)
