### PR TITLE
chore: add instructions on building multi-platform images

### DIFF
--- a/examples/function/asyncio-reduce/Makefile
+++ b/examples/function/asyncio-reduce/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t asynctest:v1 .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/asynctest:v1" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/counter/Makefile
+++ b/examples/function/counter/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/reduce-counter:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/reduce-counter:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/even_odd/Makefile
+++ b/examples/function/even_odd/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/even-odd:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/even-odd:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/event_time_filter/Makefile
+++ b/examples/function/event_time_filter/Makefile
@@ -1,5 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:latest" .
-# To build an image that is compatible with Github CI runner platform linux/amd64, use the following docker build command
-# docker buildx build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:latest" --platform linux/amd64 .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/flatmap/Makefile
+++ b/examples/function/flatmap/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/map-flatmap:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/flatmap_stream/Makefile
+++ b/examples/function/flatmap_stream/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/forward_message/Makefile
+++ b/examples/function/forward_message/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/map-forward-message:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/map-forward-message:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/function/multiproc_map/Makefile
+++ b/examples/function/multiproc_map/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/multiproc:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/multiproc:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/sink/async_log/Makefile
+++ b/examples/sink/async_log/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/async-sink-log:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/async-sink-log:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix

--- a/examples/sink/log/Makefile
+++ b/examples/sink/log/Makefile
@@ -1,3 +1,8 @@
 .PHONY: image
 image:
 	docker build -t "quay.io/numaio/numaflow-python/sink-log:latest" .
+# Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
+# under the CI E2E test environment.
+# To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command
+# docker buildx build -t "quay.io/numaio/numaflow-python/sink-log:latest" --platform linux/amd64,linux/arm64 . --push
+# If command failed, refer to https://billglover.me/notes/build-multi-arch-docker-images/ to fix


### PR DESCRIPTION
If a developer uses a non `linux/amd64` laptop to build udf images, the built images won't work under the Github CI runner hence fail the E2E tests. This code change gives instructions on how to build multi-platform images such that developers can push images that support running E2E tests both locally and on Github CI.
