### PR TITLE
chore: unify the event time of messages to drop

### DIFF
--- a/pynumaflow/_constants.py
+++ b/pynumaflow/_constants.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone, timedelta
+
 MAP_SOCK_PATH = "/var/run/numaflow/map.sock"
 MAP_STREAM_SOCK_PATH = "/var/run/numaflow/mapstream.sock"
 REDUCE_SOCK_PATH = "/var/run/numaflow/reduce.sock"
@@ -16,3 +18,8 @@ MAX_MESSAGE_SIZE = 1024 * 1024 * 64
 STREAM_EOF = "EOF"
 DELIMITER = ":"
 DROP = "U+005C__DROP__"
+# Watermark are at millisecond granularity, hence we use epoch(0) - 1
+# to indicate watermark is not available.
+# EVENT_TIME_FOR_DROP is used to indicate that the message is dropped,
+# hence excluded from watermark calculation.
+EVENT_TIME_FOR_DROP = datetime(1970, 1, 1, tzinfo=timezone.utc) - timedelta(milliseconds=1)

--- a/pynumaflow/sourcetransformer/__init__.py
+++ b/pynumaflow/sourcetransformer/__init__.py
@@ -1,4 +1,4 @@
-from pynumaflow.sourcetransformer._dtypes import Message, Messages, Datum, DROP, EVENT_TIME_TO_DROP
+from pynumaflow.sourcetransformer._dtypes import Message, Messages, Datum, DROP, EVENT_TIME_FOR_DROP
 from pynumaflow.sourcetransformer.multiproc_server import MultiProcSourceTransformer
 from pynumaflow.sourcetransformer.server import SourceTransformer
 
@@ -7,7 +7,7 @@ __all__ = [
     "Messages",
     "Datum",
     "DROP",
-    "EVENT_TIME_TO_DROP",
+    "EVENT_TIME_FOR_DROP",
     "SourceTransformer",
     "MultiProcSourceTransformer",
 ]

--- a/pynumaflow/sourcetransformer/__init__.py
+++ b/pynumaflow/sourcetransformer/__init__.py
@@ -1,9 +1,4 @@
-from pynumaflow.sourcetransformer._dtypes import (
-    Message,
-    Messages,
-    Datum,
-    DROP,
-)
+from pynumaflow.sourcetransformer._dtypes import Message, Messages, Datum, DROP, EVENT_TIME_TO_DROP
 from pynumaflow.sourcetransformer.multiproc_server import MultiProcSourceTransformer
 from pynumaflow.sourcetransformer.server import SourceTransformer
 
@@ -12,6 +7,7 @@ __all__ = [
     "Messages",
     "Datum",
     "DROP",
+    "EVENT_TIME_TO_DROP",
     "SourceTransformer",
     "MultiProcSourceTransformer",
 ]

--- a/pynumaflow/sourcetransformer/_dtypes.py
+++ b/pynumaflow/sourcetransformer/_dtypes.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import TypeVar, Callable
 from warnings import warn
 
-from pynumaflow._constants import DROP, EVENT_TIME_TO_DROP
+from pynumaflow._constants import DROP, EVENT_TIME_FOR_DROP
 
 M = TypeVar("M", bound="Message")
 Ms = TypeVar("Ms", bound="Messages")
@@ -44,7 +44,7 @@ class Message:
 
     @classmethod
     def to_drop(cls: type[M]) -> M:
-        return cls(b"", EVENT_TIME_TO_DROP, None, [DROP])
+        return cls(b"", EVENT_TIME_FOR_DROP, None, [DROP])
 
     @property
     def event_time(self) -> datetime:

--- a/pynumaflow/sourcetransformer/_dtypes.py
+++ b/pynumaflow/sourcetransformer/_dtypes.py
@@ -13,8 +13,9 @@ Ms = TypeVar("Ms", bound="Messages")
 @dataclass(init=False)
 class Message:
     """
-    event_time_to_drop 1969-12-31 00:00:00 +0000 UTC is set to be slightly earlier than Unix epoch -1 (1969-12-31
-    23:59:59.999 +0000 UTC) As -1 is used on Numaflow to indicate watermark is not available, event_time_to_drop is
+    event_time_to_drop 1969-12-31 00:00:00 +0000 UTC is set to be slightly
+    earlier than Unix epoch -1 (1969-12-31 23:59:59.999 +0000 UTC)
+    As -1 is used on Numaflow to indicate watermark is not available, event_time_to_drop is
     used to indicate that the message is dropped hence, excluded from watermark calculation
     """
 

--- a/pynumaflow/sourcetransformer/_dtypes.py
+++ b/pynumaflow/sourcetransformer/_dtypes.py
@@ -1,10 +1,10 @@
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import TypeVar, Callable
 from warnings import warn
 
-from pynumaflow._constants import DROP
+from pynumaflow._constants import DROP, EVENT_TIME_TO_DROP
 
 M = TypeVar("M", bound="Message")
 Ms = TypeVar("Ms", bound="Messages")
@@ -12,15 +12,6 @@ Ms = TypeVar("Ms", bound="Messages")
 
 @dataclass(init=False)
 class Message:
-    """
-    event_time_to_drop 1969-12-31 00:00:00 +0000 UTC is set to be slightly
-    earlier than Unix epoch -1 (1969-12-31 23:59:59.999 +0000 UTC)
-    As -1 is used on Numaflow to indicate watermark is not available, event_time_to_drop is
-    used to indicate that the message is dropped hence, excluded from watermark calculation
-    """
-
-    event_time_to_drop = datetime(1969, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
-
     """
     Basic datatype for data passing to the next vertex/vertices.
 
@@ -53,7 +44,7 @@ class Message:
 
     @classmethod
     def to_drop(cls: type[M]) -> M:
-        return cls(b"", Message.event_time_to_drop, None, [DROP])
+        return cls(b"", EVENT_TIME_TO_DROP, None, [DROP])
 
     @property
     def event_time(self) -> datetime:

--- a/tests/sourcetransform/test_messages.py
+++ b/tests/sourcetransform/test_messages.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime, timezone
 
-from pynumaflow.sourcetransformer import Messages, Message, DROP
+from pynumaflow.sourcetransformer import Messages, Message, DROP, EVENT_TIME_TO_DROP
 
 
 def mock_message_t():
@@ -35,14 +35,14 @@ class TestMessage(unittest.TestCase):
             "Keys": [],
             "Value": b"",
             "Tags": [DROP],
-            "EventTime": Message.event_time_to_drop,
+            "EventTime": EVENT_TIME_TO_DROP,
         }
         msgt = Message(b"", mock_event_time()).to_drop()
         self.assertEqual(Message, type(msgt))
         self.assertEqual(mock_obj["Keys"], msgt.keys)
         self.assertEqual(mock_obj["Value"], msgt.value)
         self.assertEqual(mock_obj["Tags"], msgt.tags)
-        self.assertEqual(mock_obj["EventTime"], msgt.event_time_to_drop)
+        self.assertEqual(mock_obj["EventTime"], msgt.event_time)
 
 
 class TestMessages(unittest.TestCase):

--- a/tests/sourcetransform/test_messages.py
+++ b/tests/sourcetransform/test_messages.py
@@ -31,12 +31,18 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(mock_obj["Tags"], msgt.tags)
 
     def test_message_to_drop(self):
-        mock_obj = {"Keys": [], "Value": b"", "Tags": [DROP]}
+        mock_obj = {
+            "Keys": [],
+            "Value": b"",
+            "Tags": [DROP],
+            "EventTime": Message.event_time_to_drop,
+        }
         msgt = Message(b"", mock_event_time()).to_drop()
         self.assertEqual(Message, type(msgt))
         self.assertEqual(mock_obj["Keys"], msgt.keys)
         self.assertEqual(mock_obj["Value"], msgt.value)
         self.assertEqual(mock_obj["Tags"], msgt.tags)
+        self.assertEqual(mock_obj["EventTime"], msgt.event_time_to_drop)
 
 
 class TestMessages(unittest.TestCase):

--- a/tests/sourcetransform/test_messages.py
+++ b/tests/sourcetransform/test_messages.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime, timezone
 
-from pynumaflow.sourcetransformer import Messages, Message, DROP, EVENT_TIME_TO_DROP
+from pynumaflow.sourcetransformer import Messages, Message, DROP, EVENT_TIME_FOR_DROP
 
 
 def mock_message_t():
@@ -35,7 +35,7 @@ class TestMessage(unittest.TestCase):
             "Keys": [],
             "Value": b"",
             "Tags": [DROP],
-            "EventTime": EVENT_TIME_TO_DROP,
+            "EventTime": EVENT_TIME_FOR_DROP,
         }
         msgt = Message(b"", mock_event_time()).to_drop()
         self.assertEqual(Message, type(msgt))


### PR DESCRIPTION
Set the event time of messages to drop to epoch(0) - 1ms across all our SDKs.
