### PR TITLE
fix: typo in async_server.py

### DIFF
--- a/pynumaflow/sourcer/async_server.py
+++ b/pynumaflow/sourcer/async_server.py
@@ -181,7 +181,7 @@ class AsyncSourcer(source_pb2_grpc.SourceServicer):
         return source_pb2.PendingResponse(result=resp)
 
     async def __serve_async(self, server) -> None:
-        source_pb2_grpc.add_sourceServicer_to_server(
+        source_pb2_grpc.add_SourceServicer_to_server(
             AsyncSourcer(read_handler=self.__source_read_handler),
             server,
         )


### PR DESCRIPTION
Fix typo in async_server.py. The function `add_sourceServicer_to_server` needs to read `add_SourceServicer_to_server`.

closes #117