### PR TITLE
chore: update examples

### DIFF
--- a/examples/map/flatmap/Makefile
+++ b/examples/map/flatmap/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:v0.6.1" .
+	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:v0.6.0" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/map/flatmap/Makefile
+++ b/examples/map/flatmap/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:v0.6.2" .
+	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:v0.6.1" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/map/flatmap/Makefile
+++ b/examples/map/flatmap/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:v0.5.0" .
+	docker build -t "quay.io/numaio/numaflow-python/map-flatmap:v0.6.2" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/map/flatmap/pipeline.yaml
+++ b/examples/map/flatmap/pipeline.yaml
@@ -15,7 +15,7 @@ spec:
     - name: flatmap
       udf:
         container:
-          image: "quay.io/numaio/numaflow-python/map-flatmap:v0.6.1"
+          image: "quay.io/numaio/numaflow-python/map-flatmap:v0.6.0"
           env:
             - name: PYTHONDEBUG
               value: "true"

--- a/examples/map/flatmap/pipeline.yaml
+++ b/examples/map/flatmap/pipeline.yaml
@@ -15,7 +15,7 @@ spec:
     - name: flatmap
       udf:
         container:
-          image: "quay.io/numaio/numaflow-python/map-flatmap:v0.7.0"
+          image: "quay.io/numaio/numaflow-python/map-flatmap:v0.6.2"
           env:
             - name: PYTHONDEBUG
               value: "true"

--- a/examples/map/flatmap/pipeline.yaml
+++ b/examples/map/flatmap/pipeline.yaml
@@ -15,7 +15,7 @@ spec:
     - name: flatmap
       udf:
         container:
-          image: "quay.io/numaio/numaflow-python/map-flatmap:v0.6.2"
+          image: "quay.io/numaio/numaflow-python/map-flatmap:v0.6.1"
           env:
             - name: PYTHONDEBUG
               value: "true"

--- a/examples/map/flatmap/pyproject.toml
+++ b/examples/map/flatmap/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776"}
+pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776" }
 
 
 [tool.poetry.dev-dependencies]

--- a/examples/map/flatmap/pyproject.toml
+++ b/examples/map/flatmap/pyproject.toml
@@ -8,7 +8,6 @@ authors = ["Numaflow developers"]
 python = "~3.10"
 pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776" }
 
-
 [tool.poetry.dev-dependencies]
 
 [build-system]

--- a/examples/map/flatmap/pyproject.toml
+++ b/examples/map/flatmap/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.7.0"
+pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776"}
 
 
 [tool.poetry.dev-dependencies]

--- a/examples/mapstream/flatmap_stream/Makefile
+++ b/examples/mapstream/flatmap_stream/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.1" .
+	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.2" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/mapstream/flatmap_stream/Makefile
+++ b/examples/mapstream/flatmap_stream/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.2" .
+	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.1" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/mapstream/flatmap_stream/Makefile
+++ b/examples/mapstream/flatmap_stream/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.1" .
+	docker build -t "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.0" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/mapstream/flatmap_stream/pipeline.yaml
+++ b/examples/mapstream/flatmap_stream/pipeline.yaml
@@ -20,7 +20,7 @@ spec:
         readBatchSize: 1
       udf:
         container:
-          image: "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.2"
+          image: "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.1"
           imagePullPolicy: Always
           env:
             - name: PYTHONDEBUG

--- a/examples/mapstream/flatmap_stream/pipeline.yaml
+++ b/examples/mapstream/flatmap_stream/pipeline.yaml
@@ -20,7 +20,7 @@ spec:
         readBatchSize: 1
       udf:
         container:
-          image: "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.1"
+          image: "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.0"
           imagePullPolicy: Always
           env:
             - name: PYTHONDEBUG

--- a/examples/mapstream/flatmap_stream/pipeline.yaml
+++ b/examples/mapstream/flatmap_stream/pipeline.yaml
@@ -20,7 +20,7 @@ spec:
         readBatchSize: 1
       udf:
         container:
-          image: "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.1"
+          image: "quay.io/numaio/numaflow-python/map-flatmap-stream:v0.6.2"
           imagePullPolicy: Always
           env:
             - name: PYTHONDEBUG

--- a/examples/mapstream/flatmap_stream/pyproject.toml
+++ b/examples/mapstream/flatmap_stream/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.7.0"
+pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776" }
 
 [tool.poetry.dev-dependencies]
 

--- a/examples/sink/log/Makefile
+++ b/examples/sink/log/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/sink-log:v0.7.0" .
+	docker build -t "quay.io/numaio/numaflow-python/sink-log:v0.6.2" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/sink/log/Makefile
+++ b/examples/sink/log/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/sink-log:v0.6.2" .
+	docker build -t "quay.io/numaio/numaflow-python/sink-log:v0.6.1" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/sink/log/Makefile
+++ b/examples/sink/log/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/sink-log:v0.6.1" .
+	docker build -t "quay.io/numaio/numaflow-python/sink-log:v0.6.0" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/sink/log/pipeline-numaflow.yaml
+++ b/examples/sink/log/pipeline-numaflow.yaml
@@ -21,7 +21,7 @@ spec:
             args:
             - python
             - example.py
-            image: "quay.io/numaio/numaflow-python/sink-log:v0.6.2"
+            image: "quay.io/numaio/numaflow-python/sink-log:v0.6.1"
             imagePullPolicy: Always
             env:
               - name: PYTHONDEBUG

--- a/examples/sink/log/pipeline-numaflow.yaml
+++ b/examples/sink/log/pipeline-numaflow.yaml
@@ -21,7 +21,7 @@ spec:
             args:
             - python
             - example.py
-            image: "quay.io/numaio/numaflow-python/sink-log:v0.7.0"
+            image: "quay.io/numaio/numaflow-python/sink-log:v0.6.2"
             imagePullPolicy: Always
             env:
               - name: PYTHONDEBUG

--- a/examples/sink/log/pipeline-numaflow.yaml
+++ b/examples/sink/log/pipeline-numaflow.yaml
@@ -21,7 +21,7 @@ spec:
             args:
             - python
             - example.py
-            image: "quay.io/numaio/numaflow-python/sink-log:v0.6.1"
+            image: "quay.io/numaio/numaflow-python/sink-log:v0.6.0"
             imagePullPolicy: Always
             env:
               - name: PYTHONDEBUG

--- a/examples/sink/log/pyproject.toml
+++ b/examples/sink/log/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.7.0"
+pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776" }
 
 [tool.poetry.dev-dependencies]
 

--- a/examples/source/simple-source/Makefile
+++ b/examples/source/simple-source/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/simple-source:v0.6.1" .
+	docker build -t "quay.io/numaio/numaflow-python/simple-source:v0.6.0" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/source/simple-source/Makefile
+++ b/examples/source/simple-source/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/simple-source:v0.7.0" .
+	docker build -t "quay.io/numaio/numaflow-python/simple-source:v0.6.1" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/source/simple-source/pipeline-numaflow.yaml
+++ b/examples/source/simple-source/pipeline-numaflow.yaml
@@ -9,7 +9,7 @@ spec:
         udsource:
           container:
             # A simple user-defined source for e2e testing
-            image: quay.io/numaio/numaflow-python/simple-source:v0.6.1
+            image: quay.io/numaio/numaflow-python/simple-source:v0.6.0
             imagePullPolicy: Always
       limits:
         readBatchSize: 2

--- a/examples/source/simple-source/pipeline-numaflow.yaml
+++ b/examples/source/simple-source/pipeline-numaflow.yaml
@@ -9,7 +9,7 @@ spec:
         udsource:
           container:
             # A simple user-defined source for e2e testing
-            image: quay.io/numaio/numaflow-python/simple-source:v0.7.0
+            image: quay.io/numaio/numaflow-python/simple-source:v0.6.1
             imagePullPolicy: Always
       limits:
         readBatchSize: 2

--- a/examples/source/simple-source/pyproject.toml
+++ b/examples/source/simple-source/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Numaflow developers"]
 
 [tool.poetry.dependencies]
 python = "~3.10"
-pynumaflow = "~0.7.0"
+pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776" }
 
 [tool.poetry.dev-dependencies]
 

--- a/examples/sourcetransform/event_time_filter/Makefile
+++ b/examples/sourcetransform/event_time_filter/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:v0.6.2" .
+	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:v0.6.1" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/sourcetransform/event_time_filter/Makefile
+++ b/examples/sourcetransform/event_time_filter/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:v0.7.0" .
+	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:v0.6.2" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/sourcetransform/event_time_filter/Makefile
+++ b/examples/sourcetransform/event_time_filter/Makefile
@@ -1,6 +1,6 @@
 .PHONY: image
 image:
-	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:v0.6.1" .
+	docker build -t "quay.io/numaio/numaflow-python/mapt-event-time-filter:v0.6.0" .
 # Github CI runner uses platform linux/amd64. If your local environment don't, the image built by command above might not work
 # under the CI E2E test environment.
 # To build an image that supports multiple platforms(linux/amd64,linux/arm64) and push to quay.io, use the following command

--- a/examples/sourcetransform/event_time_filter/pyproject.toml
+++ b/examples/sourcetransform/event_time_filter/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "mapt_event_time_filter"}]
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.12"
-pynumaflow = "~0.7.0"
+pynumaflow = { git = "https://github.com/numaproj/numaflow-python.git", rev = "897ebc49ca3db21bd9eeb91b09c9607e910d6776" }
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Updating example images in order to use the newest sdk versions required to pass e2e tests in [#1456](https://github.com/numaproj/numaflow/issues/1456)