### PR TITLE
chore: bump release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pynumaflow"
-version = "0.6.0"
+version = "0.7.0a0"
 description = "Provides the interfaces of writing Python User Defined Functions and Sinks for NumaFlow."
 authors = ["NumaFlow Developers"]
 readme = "README.md"


### PR DESCRIPTION
Change release version to 0.7.0a0
Semantic versioning through `poetry version preminor`
