### PR TITLE
chore: fix docker builds for examples

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,8 +1,6 @@
 name: Docker Publish
 
 on:
-  pull_request:
-    branches: [ "main" ]
   push:
     branches: [ main ]
     tags:

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -20,16 +20,13 @@ jobs:
         # TODO: rewrite asyncio_reduce example using latest SDK version, as it is currently using old methods
         # then add to example_directories matrix
         example_directories: [
+          "examples/map/even_odd", "examples/map/flatmap", "examples/map/forward_message",
+          "examples/map/multiproc_map", "examples/mapstream/flatmap_stream", "examples/reduce/counter",
+          "examples/reducestream/counter", "examples/reducestream/sum", "examples/sideinput/simple_sideinput",
+          "examples/sideinput/simple_sideinput/udf", "examples/sink/async_log", "examples/sink/log",
+          "examples/source/simple_source", "examples/sourcetransform/event_time_filter",
           "examples/batchmap/flatmap"
         ]
-#        example_directories: [
-#          "examples/map/even_odd", "examples/map/flatmap", "examples/map/forward_message",
-#          "examples/map/multiproc_map", "examples/mapstream/flatmap_stream", "examples/reduce/counter",
-#          "examples/reducestream/counter", "examples/reducestream/sum", "examples/sideinput/simple_sideinput",
-#          "examples/sideinput/simple_sideinput/udf", "examples/sink/async_log", "examples/sink/log",
-#          "examples/source/simple_source", "examples/sourcetransform/event_time_filter",
-#          "examples/batchmap/flatmap"
-#        ]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,6 +1,8 @@
 name: Docker Publish
 
 on:
+  pull_request:
+    branches: [ "main" ]
   push:
     branches: [ main ]
     tags:
@@ -18,13 +20,16 @@ jobs:
         # TODO: rewrite asyncio_reduce example using latest SDK version, as it is currently using old methods
         # then add to example_directories matrix
         example_directories: [
-          "examples/map/even_odd", "examples/map/flatmap", "examples/map/forward_message",
-          "examples/map/multiproc_map", "examples/mapstream/flatmap_stream", "examples/reduce/counter",
-          "examples/reducestream/counter", "examples/reducestream/sum", "examples/sideinput/simple_sideinput",
-          "examples/sideinput/simple_sideinput/udf", "examples/sink/async_log", "examples/sink/log",
-          "examples/source/simple_source", "examples/sourcetransform/event_time_filter",
           "examples/batchmap/flatmap"
         ]
+#        example_directories: [
+#          "examples/map/even_odd", "examples/map/flatmap", "examples/map/forward_message",
+#          "examples/map/multiproc_map", "examples/mapstream/flatmap_stream", "examples/reduce/counter",
+#          "examples/reducestream/counter", "examples/reducestream/sum", "examples/sideinput/simple_sideinput",
+#          "examples/sideinput/simple_sideinput/udf", "examples/sink/async_log", "examples/sink/log",
+#          "examples/source/simple_source", "examples/sourcetransform/event_time_filter",
+#          "examples/batchmap/flatmap"
+#        ]
 
     steps:
       - name: Check out repository

--- a/examples/batchmap/flatmap/Dockerfile
+++ b/examples/batchmap/flatmap/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
-RUN poetry lock --no-update
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/batchmap/flatmap/Dockerfile
+++ b/examples/batchmap/flatmap/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock --no-update
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/map/even_odd/Dockerfile
+++ b/examples/map/even_odd/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/map/flatmap/Dockerfile
+++ b/examples/map/flatmap/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/map/forward_message/Dockerfile
+++ b/examples/map/forward_message/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/map/multiproc_map/Dockerfile
+++ b/examples/map/multiproc_map/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/mapstream/flatmap_stream/Dockerfile
+++ b/examples/mapstream/flatmap_stream/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/reduce/counter/Dockerfile
+++ b/examples/reduce/counter/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/reducestream/counter/Dockerfile
+++ b/examples/reducestream/counter/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/reducestream/sum/Dockerfile
+++ b/examples/reducestream/sum/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/sideinput/simple_sideinput/Dockerfile
+++ b/examples/sideinput/simple_sideinput/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/sideinput/simple_sideinput/udf/Dockerfile
+++ b/examples/sideinput/simple_sideinput/udf/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/sink/async_log/Dockerfile
+++ b/examples/sink/async_log/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/sink/log/Dockerfile
+++ b/examples/sink/log/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/source/simple_source/Dockerfile
+++ b/examples/source/simple_source/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 

--- a/examples/sourcetransform/event_time_filter/Dockerfile
+++ b/examples/sourcetransform/event_time_filter/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR $PYSETUP_PATH
 COPY ./ ./
 
 WORKDIR $EXAMPLE_PATH
+RUN poetry lock
 RUN poetry install --no-cache --no-root && \
     rm -rf ~/.cache/pypoetry/
 


### PR DESCRIPTION
Have added this to unblock the builds currently, the poetry version is pinned in the example docker files which was causing the builds to fail. Hence we need to recreate with poetry lock.

This is temp fix, I will update the Dockerfiles to use an optimized version which I have for other use cases