### PR TITLE
chore: Datum keys as property

### DIFF
--- a/pynumaflow/accumulator/_dtypes.py
+++ b/pynumaflow/accumulator/_dtypes.py
@@ -76,6 +76,7 @@ class Datum:
         self._headers = headers or {}
         self._id = id_
 
+    @property
     def keys(self) -> list[str]:
         """Returns the keys of the event.
 
@@ -488,7 +489,7 @@ class Message:
         """
         return cls(
             value=datum.value,
-            keys=datum.keys(),
+            keys=datum.keys,
             watermark=datum.watermark,
             event_time=datum.event_time,
             headers=datum.headers,

--- a/pynumaflow/accumulator/servicer/task_manager.py
+++ b/pynumaflow/accumulator/servicer/task_manager.py
@@ -106,7 +106,7 @@ class TaskManager:
         4. Remove the task from the tracker
         """
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys)
         curr_task = self.tasks.get(unified_key, None)
 
@@ -128,7 +128,7 @@ class TaskManager:
         it creates a new task or appends the request to the existing task.
         """
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys)
         curr_task = self.tasks.get(unified_key, None)
 
@@ -179,7 +179,7 @@ class TaskManager:
         If the task does not exist, create it.
         """
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys)
         result = self.tasks.get(unified_key, None)
         if not result:

--- a/pynumaflow/batchmapper/_dtypes.py
+++ b/pynumaflow/batchmapper/_dtypes.py
@@ -99,6 +99,7 @@ class Datum:
         self._watermark = watermark
         self._headers = headers or {}
 
+    @property
     def keys(self) -> list[str]:
         """Returns the keys of the event"""
         return self._keys

--- a/pynumaflow/mapstreamer/_dtypes.py
+++ b/pynumaflow/mapstreamer/_dtypes.py
@@ -151,6 +151,7 @@ class Datum:
         self._watermark = watermark
         self._headers = headers or {}
 
+    @property
     def keys(self) -> list[str]:
         """Returns the keys of the event"""
         return self._keys

--- a/pynumaflow/reducer/_dtypes.py
+++ b/pynumaflow/reducer/_dtypes.py
@@ -167,6 +167,7 @@ class Datum:
         self._watermark = watermark
         self._headers = headers or {}
 
+    @property
     def keys(self) -> list[str]:
         """Returns the keys of the event"""
         return self._keys

--- a/pynumaflow/reducer/servicer/task_manager.py
+++ b/pynumaflow/reducer/servicer/task_manager.py
@@ -108,7 +108,7 @@ class TaskManager:
             raise UDFError("reduce create operation error: invalid number of windows")
 
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys, req.windows[0])
         result = self.tasks.get(unified_key, None)
 
@@ -137,7 +137,7 @@ class TaskManager:
         if len(req.windows) != 1:
             raise UDFError("reduce create operation error: invalid number of windows")
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys, req.windows[0])
         result = self.tasks.get(unified_key, None)
         if not result:

--- a/pynumaflow/reducestreamer/_dtypes.py
+++ b/pynumaflow/reducestreamer/_dtypes.py
@@ -73,6 +73,7 @@ class Datum:
         self._watermark = watermark
         self._headers = headers or {}
 
+    @property
     def keys(self) -> list[str]:
         """Returns the keys of the event"""
         return self._keys

--- a/pynumaflow/reducestreamer/servicer/task_manager.py
+++ b/pynumaflow/reducestreamer/servicer/task_manager.py
@@ -110,7 +110,7 @@ class TaskManager:
             raise UDFError("reduce create operation error: invalid number of windows")
 
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys, req.windows[0])
         curr_task = self.tasks.get(unified_key, None)
 
@@ -161,7 +161,7 @@ class TaskManager:
         if len(req.windows) != 1:
             raise UDFError("reduce append operation error: invalid number of windows")
         d = req.payload
-        keys = d.keys()
+        keys = d.keys
         unified_key = build_unique_key_name(keys, req.windows[0])
         result = self.tasks.get(unified_key, None)
         if not result:

--- a/pynumaflow/sourcetransformer/_dtypes.py
+++ b/pynumaflow/sourcetransformer/_dtypes.py
@@ -160,6 +160,7 @@ class Datum:
         self._watermark = watermark
         self._headers = headers or {}
 
+    @property
     def keys(self) -> list[str]:
         """Returns the keys of the event"""
         return self._keys

--- a/tests/accumulator/test_async_accumulator.py
+++ b/tests/accumulator/test_async_accumulator.py
@@ -140,7 +140,7 @@ class ExampleClass(Accumulator):
         async for datum in datums:
             self.counter += 1
             msg = f"counter:{self.counter}"
-            await output.put(Message(str.encode(msg), keys=datum.keys(), tags=[]))
+            await output.put(Message(str.encode(msg), keys=datum.keys, tags=[]))
 
 
 async def accumulator_handler_func(datums: AsyncIterable[Datum], output: NonBlockingIterator):
@@ -148,7 +148,7 @@ async def accumulator_handler_func(datums: AsyncIterable[Datum], output: NonBloc
     async for datum in datums:
         counter += 1
         msg = f"counter:{counter}"
-        await output.put(Message(str.encode(msg), keys=datum.keys(), tags=[]))
+        await output.put(Message(str.encode(msg), keys=datum.keys, tags=[]))
 
 
 def NewAsyncAccumulator():

--- a/tests/accumulator/test_async_accumulator_err.py
+++ b/tests/accumulator/test_async_accumulator_err.py
@@ -79,7 +79,7 @@ class ExampleErrorClass(Accumulator):
                 # Simulate an error on the second datum
                 raise RuntimeError("Simulated error in accumulator handler")
             msg = f"counter:{self.counter}"
-            await output.put(Message(str.encode(msg), keys=datum.keys(), tags=[]))
+            await output.put(Message(str.encode(msg), keys=datum.keys, tags=[]))
 
 
 async def error_accumulator_handler_func(datums: AsyncIterable[Datum], output: NonBlockingIterator):
@@ -90,7 +90,7 @@ async def error_accumulator_handler_func(datums: AsyncIterable[Datum], output: N
             # Simulate an error on the second datum
             raise RuntimeError("Simulated error in accumulator function")
         msg = f"counter:{counter}"
-        await output.put(Message(str.encode(msg), keys=datum.keys(), tags=[]))
+        await output.put(Message(str.encode(msg), keys=datum.keys, tags=[]))
 
 
 def NewAsyncAccumulatorError():

--- a/tests/accumulator/test_datatypes.py
+++ b/tests/accumulator/test_datatypes.py
@@ -77,7 +77,7 @@ class TestDatum(unittest.TestCase):
             headers=TEST_HEADERS,
         )
         self.assertEqual(mock_message(), d.value)
-        self.assertEqual(TEST_KEYS, d.keys())
+        self.assertEqual(TEST_KEYS, d.keys)
         self.assertEqual(mock_event_time(), d.event_time)
         self.assertEqual(mock_watermark(), d.watermark)
         self.assertEqual(TEST_HEADERS, d.headers)
@@ -91,7 +91,7 @@ class TestDatum(unittest.TestCase):
             watermark=mock_watermark(),
             id_=TEST_ID,
         )
-        self.assertEqual([], d.keys())
+        self.assertEqual([], d.keys)
         self.assertEqual(b"", d.value)
         self.assertEqual({}, d.headers)
 

--- a/tests/batchmap/test_datatypes.py
+++ b/tests/batchmap/test_datatypes.py
@@ -72,7 +72,7 @@ class TestDatum(unittest.TestCase):
             watermark=mock_watermark(),
             id=TEST_ID,
         )
-        self.assertEqual(TEST_KEYS, d.keys())
+        self.assertEqual(TEST_KEYS, d.keys)
 
     def test_event_time(self):
         d = Datum(

--- a/tests/reduce/test_datatypes.py
+++ b/tests/reduce/test_datatypes.py
@@ -75,7 +75,7 @@ class TestDatum(unittest.TestCase):
             event_time=mock_event_time(),
             watermark=mock_watermark(),
         )
-        self.assertEqual(TEST_KEYS, d.keys())
+        self.assertEqual(TEST_KEYS, d.keys)
 
     def test_event_time(self):
         d = Datum(

--- a/tests/reducestreamer/test_datatypes.py
+++ b/tests/reducestreamer/test_datatypes.py
@@ -76,7 +76,7 @@ class TestDatum(unittest.TestCase):
             event_time=mock_event_time(),
             watermark=mock_watermark(),
         )
-        self.assertEqual(TEST_KEYS, d.keys())
+        self.assertEqual(TEST_KEYS, d.keys)
 
     def test_event_time(self):
         d = Datum(


### PR DESCRIPTION
Note that this is a breaking change; from now on, all the callers should call keys like `datum.keys`, not `datum.keys()`.

Close #233
