### PR TITLE
fix: Function call syntax error

### DIFF
--- a/pynumaflow/sourcer/servicer/async_servicer.py
+++ b/pynumaflow/sourcer/servicer/async_servicer.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterator
 
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 from google.protobuf import empty_pb2 as _empty_pb2
@@ -80,9 +80,9 @@ class AsyncSourceServicer(source_pb2_grpc.SourceServicer):
 
     async def ReadFn(
         self,
-        request_iterator: AsyncIterable[source_pb2.ReadRequest],
+        request_iterator: AsyncIterator[source_pb2.ReadRequest],
         context: NumaflowServicerContext,
-    ) -> AsyncIterable[source_pb2.ReadResponse]:
+    ) -> AsyncIterator[source_pb2.ReadResponse]:
         """
         Handles the Read function, processing incoming requests and sending responses.
         """
@@ -108,7 +108,7 @@ class AsyncSourceServicer(source_pb2_grpc.SourceServicer):
 
                 async for resp in riter:
                     if isinstance(resp, BaseException):
-                        await handle_async_error(context, resp)
+                        await handle_async_error(context, resp, ERR_UDF_EXCEPTION_STRING)
                         return
 
                     yield _create_read_response(resp)
@@ -139,9 +139,9 @@ class AsyncSourceServicer(source_pb2_grpc.SourceServicer):
 
     async def AckFn(
         self,
-        request_iterator: AsyncIterable[source_pb2.AckRequest],
+        request_iterator: AsyncIterator[source_pb2.AckRequest],
         context: NumaflowServicerContext,
-    ) -> AsyncIterable[source_pb2.AckResponse]:
+    ) -> AsyncIterator[source_pb2.AckResponse]:
         """
         Handles the Ack function for user-defined source.
         """

--- a/tests/source/test_async_source_err.py
+++ b/tests/source/test_async_source_err.py
@@ -9,11 +9,10 @@ import grpc
 from grpc.aio._server import Server
 
 from pynumaflow import setup_logging
-from pynumaflow._constants import ERR_UDF_EXCEPTION_STRING
-from pynumaflow.sourcer import SourceAsyncServer
 from pynumaflow.proto.sourcer import source_pb2_grpc
 from google.protobuf import empty_pb2 as _empty_pb2
 
+from pynumaflow.sourcer.async_server import SourceAsyncServer
 from tests.source.test_async_source import request_generator
 from tests.source.utils import (
     read_req_source_fn,
@@ -94,11 +93,10 @@ class TestAsyncServerErrorScenario(unittest.TestCase):
                     pass
             except grpc.RpcError as e:
                 grpc_exception = e
-                self.assertEqual(grpc.StatusCode.UNKNOWN, e.code())
+                self.assertEqual(grpc.StatusCode.INTERNAL, e.code())
                 print(e.details())
 
         self.assertIsNotNone(grpc_exception)
-        self.fail("Expected an exception.")
 
     def test_read_handshake_error(self) -> None:
         grpc_exception = None

--- a/tests/source/test_async_source_err.py
+++ b/tests/source/test_async_source_err.py
@@ -92,13 +92,6 @@ class TestAsyncServerErrorScenario(unittest.TestCase):
                 )
                 for _ in generator_response:
                     pass
-            except BaseException as e:
-                self.assertTrue(
-                    f"{ERR_UDF_EXCEPTION_STRING}: TypeError("
-                    '"handle_async_error() missing 1 required positional argument: '
-                    "'exception_type'\")" in e.__str__()
-                )
-                return
             except grpc.RpcError as e:
                 grpc_exception = e
                 self.assertEqual(grpc.StatusCode.UNKNOWN, e.code())

--- a/tests/source/test_async_source_err.py
+++ b/tests/source/test_async_source_err.py
@@ -12,7 +12,7 @@ from pynumaflow import setup_logging
 from pynumaflow.proto.sourcer import source_pb2_grpc
 from google.protobuf import empty_pb2 as _empty_pb2
 
-from pynumaflow.sourcer.async_server import SourceAsyncServer
+from pynumaflow.sourcer import SourceAsyncServer
 from tests.source.test_async_source import request_generator
 from tests.source.utils import (
     read_req_source_fn,


### PR DESCRIPTION
Fix a syntax error. 

Also, the type of `request_iterator` in grpc streaming is an `AsyncIterator`, not `AsyncIterable` (https://grpc.io/docs/languages/python/basics/#request-streaming-rpc). We call `__anext__` in the body (if it was `AsyncIterable`, it should have been `request_iterator.__aiter__().__anext__()` or `anext(aiter(generator_response))` in Python > 3.10.

I'm also changing return type to be `AsyncIterator` (from `AsyncIterable`). Functionally, both are same and users shouldn't see any issues. The `AsyncIterator` is more restrictive, and is exhausted once iterated over. `AsyncIterable` indicates that the iterator can be created any number of times by calling `aiter(obj)`.