### PR TITLE
feat(streamsorter): flush on timeout, adjust logging

### DIFF
--- a/packages/pynumaflow/examples/accumulator/streamsorter/example.py
+++ b/packages/pynumaflow/examples/accumulator/streamsorter/example.py
@@ -57,7 +57,7 @@ class StreamSorter(Accumulator):
                 left = mid + 1
         self.sorted_buffer.insert(left, datum)
 
-    async def flush_buffer(self, output: NonBlockingIterator, flush_all: bool=False):
+    async def flush_buffer(self, output: NonBlockingIterator, flush_all: bool = False):
         if flush_all:
             _LOGGER.info("Flushing entire sortedBuffer")
         else:


### PR DESCRIPTION
Fixes #278

This _should_ solve the issue, BUT the `_LOGGER.info("Timeout reached")` is never reached, when I stop posing events. Please test and advice.

Tested according to [streamsorter README](https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/examples/accumulator/streamsorter/README.md).

Posting with `curl -kq -X POST -d "101" https://localhost:8444/vertices/http-one`.

```text
$ kubectl logs stream-sorter-py-accum-0-f0t22
+ python example.py
2025-10-20 21:07:17 INFO     Starting Async Accumulator Server
2025-10-20 21:07:17 INFO     Async GRPC Server listening on: unix:///var/run/numaflow/accumulator.sock with max threads: 4
2025-10-20 21:08:16 INFO     StreamSorter initialized
2025-10-20 21:08:16 INFO     StreamSorter handler started
2025-10-20 21:08:16 INFO     Received datum with event time: 2025-10-20 21:08:16.221922, Current latest watermark: 1969-12-31 23:59:59, Datum watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:16 INFO     Watermark updated: 1969-12-31 23:59:59.999000
2025-10-20 21:08:16 INFO     Flushing sortedBuffer above watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:21 INFO     Received datum with event time: 2025-10-20 21:08:21.025275, Current latest watermark: 1969-12-31 23:59:59.999000, Datum watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:23 INFO     Received datum with event time: 2025-10-20 21:08:23.012079, Current latest watermark: 1969-12-31 23:59:59.999000, Datum watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:23 INFO     Received datum with event time: 2025-10-20 21:08:23.863130, Current latest watermark: 1969-12-31 23:59:59.999000, Datum watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:25 INFO     Received datum with event time: 2025-10-20 21:08:25.928153, Current latest watermark: 1969-12-31 23:59:59.999000, Datum watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:27 INFO     Received datum with event time: 2025-10-20 21:08:27.184944, Current latest watermark: 1969-12-31 23:59:59.999000, Datum watermark: 1969-12-31 23:59:59.999000
2025-10-20 21:08:28 INFO     Received datum with event time: 2025-10-20 21:08:28.092978, Current latest watermark: 1969-12-31 23:59:59.999000, Datum watermark: 2025-10-20 21:08:23.863000
2025-10-20 21:08:28 INFO     Watermark updated: 2025-10-20 21:08:23.863000
2025-10-20 21:08:28 INFO     Flushing sortedBuffer above watermark: 2025-10-20 21:08:23.863000
2025-10-20 21:08:28 INFO     Sent datum with event time: 2025-10-20 21:08:16.221922
2025-10-20 21:08:28 INFO     Sent datum with event time: 2025-10-20 21:08:21.025275
2025-10-20 21:08:28 INFO     Sent datum with event time: 2025-10-20 21:08:23.012079
2025-10-20 21:08:38 INFO     Received datum with event time: 2025-10-20 21:08:38.011048, Current latest watermark: 2025-10-20 21:08:23.863000, Datum watermark: 2025-10-20 21:08:23.863000
2025-10-20 21:08:42 INFO     Received datum with event time: 2025-10-20 21:08:42.753685, Current latest watermark: 2025-10-20 21:08:23.863000, Datum watermark: 2025-10-20 21:08:23.863000
2025-10-20 21:08:53 INFO     Received datum with event time: 2025-10-20 21:08:53.023183, Current latest watermark: 2025-10-20 21:08:23.863000, Datum watermark: 2025-10-20 21:08:38.011000
2025-10-20 21:08:53 INFO     Watermark updated: 2025-10-20 21:08:38.011000
2025-10-20 21:08:53 INFO     Flushing sortedBuffer above watermark: 2025-10-20 21:08:38.011000
2025-10-20 21:08:53 INFO     Sent datum with event time: 2025-10-20 21:08:23.863130
2025-10-20 21:08:53 INFO     Sent datum with event time: 2025-10-20 21:08:25.928153
2025-10-20 21:08:53 INFO     Sent datum with event time: 2025-10-20 21:08:27.184944
2025-10-20 21:08:53 INFO     Sent datum with event time: 2025-10-20 21:08:28.092978
2025-10-20 21:08:55 INFO     Received datum with event time: 2025-10-20 21:08:55.062887, Current latest watermark: 2025-10-20 21:08:38.011000, Datum watermark: 2025-10-20 21:08:42.753000
2025-10-20 21:08:55 INFO     Watermark updated: 2025-10-20 21:08:42.753000
2025-10-20 21:08:55 INFO     Flushing sortedBuffer above watermark: 2025-10-20 21:08:42.753000
2025-10-20 21:08:55 INFO     Sent datum with event time: 2025-10-20 21:08:38.011048
2025-10-20 21:08:56 INFO     Received datum with event time: 2025-10-20 21:08:56.185725, Current latest watermark: 2025-10-20 21:08:42.753000, Datum watermark: 2025-10-20 21:08:42.753000
2025-10-20 21:08:56 INFO     Received datum with event time: 2025-10-20 21:08:56.940796, Current latest watermark: 2025-10-20 21:08:42.753000, Datum watermark: 2025-10-20 21:08:42.753000
2025-10-20 21:08:57 INFO     Received datum with event time: 2025-10-20 21:08:57.696604, Current latest watermark: 2025-10-20 21:08:42.753000, Datum watermark: 2025-10-20 21:08:42.753000
```