### PR TITLE
feat: support shutdown_callback argument in XXXAsyncServer

### DIFF
--- a/packages/pynumaflow/pynumaflow/accumulator/async_server.py
+++ b/packages/pynumaflow/pynumaflow/accumulator/async_server.py
@@ -73,6 +73,9 @@ class AccumulatorAsyncServer(NumaflowServer):
         max_threads: The max number of threads to be spawned;
         defaults to 4 and max capped at 16
         server_info_file: The path to the server info file
+        shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
 
     Example invocation:
     ```py
@@ -139,6 +142,7 @@ class AccumulatorAsyncServer(NumaflowServer):
         max_message_size=MAX_MESSAGE_SIZE,
         max_threads=NUM_THREADS_DEFAULT,
         server_info_file=ACCUMULATOR_SERVER_INFO_FILE_PATH,
+        shutdown_callback=None,
     ):
         init_kwargs = init_kwargs or {}
         self.accumulator_handler = get_handler(accumulator_instance, init_args, init_kwargs)
@@ -146,6 +150,7 @@ class AccumulatorAsyncServer(NumaflowServer):
         self.max_message_size = max_message_size
         self.max_threads = min(max_threads, MAX_NUM_THREADS)
         self.server_info_file = server_info_file
+        self.shutdown_callback = shutdown_callback
 
         self._server_options = [
             ("grpc.max_send_message_length", self.max_message_size),
@@ -162,7 +167,7 @@ class AccumulatorAsyncServer(NumaflowServer):
         _LOGGER.info(
             "Starting Async Accumulator Server",
         )
-        aiorun.run(self.aexec(), use_uvloop=True)
+        aiorun.run(self.aexec(), use_uvloop=True, shutdown_callback=self.shutdown_callback)
 
     async def aexec(self):
         """

--- a/packages/pynumaflow/pynumaflow/batchmapper/async_server.py
+++ b/packages/pynumaflow/pynumaflow/batchmapper/async_server.py
@@ -34,6 +34,7 @@ class BatchMapAsyncServer(NumaflowServer):
         max_message_size=MAX_MESSAGE_SIZE,
         max_threads=NUM_THREADS_DEFAULT,
         server_info_file=MAP_SERVER_INFO_FILE_PATH,
+        shutdown_callback=None,
     ):
         """
         Create a new grpc Async Batch Map Server instance.
@@ -46,6 +47,10 @@ class BatchMapAsyncServer(NumaflowServer):
             max_message_size: The max message size in bytes the server can receive and send
             max_threads: The max number of threads to be spawned;
                             defaults to 4 and max capped at 16
+            server_info_file: The path to the server info file
+            shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
 
         Example invocation:
         ```py
@@ -79,6 +84,7 @@ class BatchMapAsyncServer(NumaflowServer):
         self.max_threads = min(max_threads, MAX_NUM_THREADS)
         self.max_message_size = max_message_size
         self.server_info_file = server_info_file
+        self.shutdown_callback = shutdown_callback
 
         self._server_options = [
             ("grpc.max_send_message_length", self.max_message_size),
@@ -92,7 +98,7 @@ class BatchMapAsyncServer(NumaflowServer):
         Starter function for the Async Batch Map server, we need a separate caller
         to the aexec so that all the async coroutines can be started from a single context
         """
-        aiorun.run(self.aexec(), use_uvloop=True)
+        aiorun.run(self.aexec(), use_uvloop=True, shutdown_callback=self.shutdown_callback)
 
     async def aexec(self):
         """

--- a/packages/pynumaflow/pynumaflow/mapper/async_server.py
+++ b/packages/pynumaflow/pynumaflow/mapper/async_server.py
@@ -73,6 +73,10 @@ class MapAsyncServer(NumaflowServer):
             max_message_size: The max message size in bytes the server can receive and send
             max_threads: The max number of threads to be spawned;
                         defaults to 4 and max capped at 16
+            server_info_file: The path to the server info file
+            shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
         """
         self.sock_path = f"unix://{sock_path}"
         self.max_threads = min(max_threads, MAX_NUM_THREADS)

--- a/packages/pynumaflow/pynumaflow/mapstreamer/async_server.py
+++ b/packages/pynumaflow/pynumaflow/mapstreamer/async_server.py
@@ -51,6 +51,10 @@ class MapStreamAsyncServer(NumaflowServer):
             max_threads: The max number of threads to be spawned;
                             defaults to 4 and max capped at 16
             server_type: The type of server to be used
+            server_info_file: The path to the server info file
+            shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
 
         Example invocation:
         ```py

--- a/packages/pynumaflow/pynumaflow/reducer/async_server.py
+++ b/packages/pynumaflow/pynumaflow/reducer/async_server.py
@@ -64,6 +64,10 @@ class ReduceAsyncServer(NumaflowServer):
         max_message_size: The max message size in bytes the server can receive and send
         max_threads: The max number of threads to be spawned;
                         defaults to 4 and max capped at 16
+        server_info_file: The path to the server info file
+        shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
     Example invocation:
     ```py
     import os

--- a/packages/pynumaflow/pynumaflow/reducestreamer/async_server.py
+++ b/packages/pynumaflow/pynumaflow/reducestreamer/async_server.py
@@ -69,8 +69,11 @@ class ReduceStreamAsyncServer(NumaflowServer):
         sock_path: The UNIX socket path to be used for the server
         max_message_size: The max message size in bytes the server can receive and send
         max_threads: The max number of threads to be spawned;
-        defaults to 4 and max capped at 16
+            defaults to 4 and max capped at 16
         server_info_file: The path to the server info file
+        shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
 
     Example invocation:
     ```py

--- a/packages/pynumaflow/pynumaflow/sinker/async_server.py
+++ b/packages/pynumaflow/pynumaflow/sinker/async_server.py
@@ -41,6 +41,10 @@ class SinkAsyncServer(NumaflowServer):
         max_message_size: The max message size in bytes the server can receive and send
         max_threads: The max number of threads to be spawned;
                         defaults to 4 and max capped at 16
+        server_info_file: The path to the server info file
+        shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
 
     Example invocation:
     ```py

--- a/packages/pynumaflow/pynumaflow/sourcer/async_server.py
+++ b/packages/pynumaflow/pynumaflow/sourcer/async_server.py
@@ -42,6 +42,10 @@ class SourceAsyncServer(NumaflowServer):
             max_message_size: The max message size in bytes the server can receive and send
             max_threads: The max number of threads to be spawned;
                             defaults to 4 and max capped at 16
+            server_info_file: The path to the server info file
+            shutdown_callback: Callable, executed after loop is stopped, before
+                            cancelling any tasks.
+                            Useful for graceful shutdown.
 
         Example invocation:
         ```py


### PR DESCRIPTION
As discussed in #310, I updated the following code in accordance with the proposed solution.

- https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/pynumaflow/sourcer/async_server.py
- https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/pynumaflow/reducer/async_server.py
- https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/pynumaflow/reducestreamer/async_server.py
- https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/pynumaflow/mapstreamer/async_server.py
- https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/pynumaflow/mapper/async_server.py
- https://github.com/numaproj/numaflow-python/blob/main/packages/pynumaflow/pynumaflow/sinker/async_server.py