### PR TITLE
fix: add the error to the global result queue

### DIFF
--- a/packages/pynumaflow/pynumaflow/mapper/_servicer/_async_servicer.py
+++ b/packages/pynumaflow/pynumaflow/mapper/_servicer/_async_servicer.py
@@ -93,8 +93,10 @@ class AsyncMapServicer(map_pb2_grpc.MapServicer):
             # send an EOF to result queue to indicate that all tasks have completed
             await result_queue.put(STREAM_EOF)
 
-        except BaseException:
+        except BaseException as e:
             _LOGGER.critical("MapFn Error, re-raising the error", exc_info=True)
+            # Surface the error to the consumer; MapFn will handle and exit
+            await result_queue.put(e)
 
     async def _invoke_map(self, req: map_pb2.MapRequest, result_queue: NonBlockingIterator):
         """

--- a/packages/pynumaflow/pynumaflow/mapper/_servicer/_sync_servicer.py
+++ b/packages/pynumaflow/pynumaflow/mapper/_servicer/_sync_servicer.py
@@ -92,8 +92,10 @@ class SyncMapServicer(map_pb2_grpc.MapServicer):
             self.executor.shutdown(wait=True)
             # Indicate to the result queue that no more messages left to process
             result_queue.put(STREAM_EOF)
-        except BaseException:
+        except BaseException as e:
             _LOGGER.critical("MapFn Error, re-raising the error", exc_info=True)
+            # Surface the error to the consumer; MapFn will handle and exit
+            result_queue.put(e)
 
     def _invoke_map(
         self,

--- a/packages/pynumaflow/pynumaflow/sourcetransformer/servicer/_async_servicer.py
+++ b/packages/pynumaflow/pynumaflow/sourcetransformer/servicer/_async_servicer.py
@@ -96,8 +96,10 @@ class SourceTransformAsyncServicer(transform_pb2_grpc.SourceTransformServicer):
             # send an EOF to result queue to indicate that all tasks have completed
             await result_queue.put(STREAM_EOF)
 
-        except BaseException:
+        except BaseException as e:
             _LOGGER.critical("SourceTransformFnError Error, re-raising the error", exc_info=True)
+            # Surface the error to the consumer; SourceTransformFn will handle and exit
+            await result_queue.put(e)
 
     async def _invoke_transform(
         self, request: transform_pb2.SourceTransformRequest, result_queue: NonBlockingIterator

--- a/packages/pynumaflow/pynumaflow/sourcetransformer/servicer/_servicer.py
+++ b/packages/pynumaflow/pynumaflow/sourcetransformer/servicer/_servicer.py
@@ -113,8 +113,10 @@ class SourceTransformServicer(transform_pb2_grpc.SourceTransformServicer):
             self.executor.shutdown(wait=True)
             # Indicate to the result queue that no more messages left to process
             result_queue.put(STREAM_EOF)
-        except BaseException:
+        except BaseException as e:
             _LOGGER.critical("SourceTransformFnError, re-raising the error", exc_info=True)
+            # Surface the error to the consumer; SourceTransformFn will handle and exit
+            result_queue.put(e)
 
     def _invoke_transformer(
         self, context, request: transform_pb2.SourceTransformRequest, result_queue: SyncIterator


### PR DESCRIPTION
Closes https://github.com/numaproj/numaflow/issues/3216

The top level error handler for map and source-transformer was missing pushing to global result queue. This means, UDF errors will be handled, but not the top level service errors.