### PR TITLE
chore: Update examples for poetry to uv migration

### DIFF
--- a/packages/pynumaflow/examples/accumulator/streamsorter/Dockerfile
+++ b/packages/pynumaflow/examples/accumulator/streamsorter/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/batchmap/flatmap/Dockerfile
+++ b/packages/pynumaflow/examples/batchmap/flatmap/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/map/even_odd/Dockerfile
+++ b/packages/pynumaflow/examples/map/even_odd/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/map/flatmap/Dockerfile
+++ b/packages/pynumaflow/examples/map/flatmap/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/map/forward_message/Dockerfile
+++ b/packages/pynumaflow/examples/map/forward_message/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/map/multiproc_map/Dockerfile
+++ b/packages/pynumaflow/examples/map/multiproc_map/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/mapstream/flatmap_stream/Dockerfile
+++ b/packages/pynumaflow/examples/mapstream/flatmap_stream/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/reduce/asyncio_reduce/Dockerfile
+++ b/packages/pynumaflow/examples/reduce/asyncio_reduce/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/reduce/counter/Dockerfile
+++ b/packages/pynumaflow/examples/reduce/counter/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/reducestream/counter/Dockerfile
+++ b/packages/pynumaflow/examples/reducestream/counter/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/reducestream/sum/Dockerfile
+++ b/packages/pynumaflow/examples/reducestream/sum/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sideinput/simple_sideinput/Dockerfile
+++ b/packages/pynumaflow/examples/sideinput/simple_sideinput/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sideinput/simple_sideinput/udf/Dockerfile
+++ b/packages/pynumaflow/examples/sideinput/simple_sideinput/udf/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sink/all_sinks/Dockerfile
+++ b/packages/pynumaflow/examples/sink/all_sinks/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sink/async_log/Dockerfile
+++ b/packages/pynumaflow/examples/sink/async_log/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sink/async_log/pipeline.yaml
+++ b/packages/pynumaflow/examples/sink/async_log/pipeline.yaml
@@ -10,10 +10,6 @@ spec:
           rpu: 1
           duration: 1s
           msgSize: 10
-    - name: p1
-      udf:
-        builtin:
-          name: cat
     - name: out
       sink:
         udsink:
@@ -22,19 +18,12 @@ spec:
             - python
             - example.py
             image: quay.io/numaio/numaflow-python/async-sink-log:stable
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             env:
               - name: PYTHONDEBUG
                 value: "true"
               - name: INVOKE
                 value: "func_handler"
-    - name: log-output
-      sink:
-        log: {}
   edges:
     - from: in
-      to: p1
-    - from: p1
       to: out
-    - from: p1
-      to: log-output

--- a/packages/pynumaflow/examples/sink/log/Dockerfile
+++ b/packages/pynumaflow/examples/sink/log/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sink/log/pipeline.yaml
+++ b/packages/pynumaflow/examples/sink/log/pipeline.yaml
@@ -10,10 +10,6 @@ spec:
           rpu: 1
           duration: 1s
           msgSize: 10
-    - name: p1
-      udf:
-        builtin:
-          name: cat
     - name: out
       sink:
         udsink:
@@ -22,19 +18,12 @@ spec:
             - python
             - example.py
             image: quay.io/numaio/numaflow-python/sink-log:stable
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             env:
               - name: PYTHONDEBUG
                 value: "true"
               - name: INVOKE
                 value: "func_handler"
-    - name: log-output
-      sink:
-        log: {}
   edges:
     - from: in
-      to: p1
-    - from: p1
       to: out
-    - from: p1
-      to: log-output

--- a/packages/pynumaflow/examples/source/simple_source/Dockerfile
+++ b/packages/pynumaflow/examples/source/simple_source/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sourcetransform/async_event_time_filter/Dockerfile
+++ b/packages/pynumaflow/examples/sourcetransform/async_event_time_filter/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000

--- a/packages/pynumaflow/examples/sourcetransform/event_time_filter/Dockerfile
+++ b/packages/pynumaflow/examples/sourcetransform/event_time_filter/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR $EXAMPLE_PATH
 COPY --from=builder $EXAMPLE_PATH/.venv $EXAMPLE_PATH/.venv
 COPY --from=builder $EXAMPLE_PATH/ $EXAMPLE_PATH/
 
-ENTRYPOINT []
-CMD ["uv", "run", "python", "example.py"]
+# NOTE: We cannot use "uv run python example.py" here because uv run reads the
+# example's pyproject.toml, finds the pynumaflow path source (path = "../../../"),
+# and tries to resolve it. In the runtime stage, the parent pynumaflow source tree
+# is not present (by design, to keep the image small), so uv run fails.
+# Instead, we activate the pre-built .venv via PATH and run python directly.
+ENV PATH="$EXAMPLE_PATH/.venv/bin:$PATH"
+CMD ["python", "example.py"]
 
 EXPOSE 5000


### PR DESCRIPTION
The [PR for migrating to uv](https://github.com/numaproj/numaflow-python/pull/335) introduced a bug in building images.

Also updates sink examples which were using older builtin map in pipeline spec.

Tested by building a few images and running them within a Numaflow pipeline.

Also tested by initializing a new project and installing package from current main:
```sh
uv add "pynumaflow @ git+https://github.com/numaproj/numaflow-python.git@febbe7a3ff5c601e5263b1276ff18a41a6a1c0c2#subdirectory=packages/pynumaflow"
```