### PR TITLE
chore: remove unused SyncSource classes

### DIFF
--- a/packages/pynumaflow/tests/source/utils.py
+++ b/packages/pynumaflow/tests/source/utils.py
@@ -1,5 +1,3 @@
-from collections.abc import Iterable
-
 from pynumaflow.shared.asynciter import NonBlockingIterator
 from pynumaflow.sourcer import ReadRequest, Message, UserMetadata
 from pynumaflow.sourcer import (

--- a/packages/pynumaflow/tests/source/utils.py
+++ b/packages/pynumaflow/tests/source/utils.py
@@ -56,28 +56,6 @@ class AsyncSource(Sourcer):
         return PartitionsResponse(partitions=mock_partitions())
 
 
-class SyncSource(Sourcer):
-    def read_handler(self, datum: ReadRequest) -> Iterable[Message]:
-        payload = b"payload:test_mock_message"
-        keys = ["test_key"]
-        offset = mock_offset()
-        event_time = mock_event_time()
-        for i in range(10):
-            yield Message(payload=payload, keys=keys, offset=offset, event_time=event_time)
-
-    def ack_handler(self, ack_request: AckRequest):
-        return
-
-    def nack_handler(self, nack_request: NackRequest):
-        return
-
-    def pending_handler(self) -> PendingResponse:
-        return PendingResponse(count=10)
-
-    def partitions_handler(self) -> PartitionsResponse:
-        return PartitionsResponse(partitions=mock_partitions())
-
-
 def read_req_source_fn() -> ReadRequest:
     request = source_pb2.ReadRequest.Request(
         num_records=10,
@@ -127,21 +105,4 @@ class AsyncSourceError(Sourcer):
         raise RuntimeError("Got a runtime error from pending handler.")
 
     async def partitions_handler(self) -> PartitionsResponse:
-        raise RuntimeError("Got a runtime error from partition handler.")
-
-
-class SyncSourceError(Sourcer):
-    def read_handler(self, datum: ReadRequest) -> Iterable[Message]:
-        raise RuntimeError("Got a runtime error from read handler.")
-
-    def ack_handler(self, ack_request: AckRequest):
-        raise RuntimeError("Got a runtime error from ack handler.")
-
-    def nack_handler(self, nack_request: NackRequest):
-        raise RuntimeError("Got a runtime error from nack handler.")
-
-    def pending_handler(self) -> PendingResponse:
-        raise RuntimeError("Got a runtime error from pending handler.")
-
-    def partitions_handler(self) -> PartitionsResponse:
         raise RuntimeError("Got a runtime error from partition handler.")


### PR DESCRIPTION
These SyncSource classes don't seem to be getting instantiated in any of the tests. So removing them from test utils.

<details>
  <summary>Test Summary (click)</summary>

```
========================================================================================== short test summary info ===========================================================================================
PASSED tests/accumulator/test_async_accumulator.py::test_accumulate
PASSED tests/accumulator/test_async_accumulator.py::test_accumulate_with_multiple_keys
PASSED tests/accumulator/test_async_accumulator.py::test_accumulate_with_close
PASSED tests/accumulator/test_async_accumulator.py::test_accumulate_append_without_open
PASSED tests/accumulator/test_async_accumulator.py::test_accumulate_append_mixed
PASSED tests/accumulator/test_async_accumulator.py::test_is_ready
PASSED tests/accumulator/test_async_accumulator.py::test_error_init
PASSED tests/accumulator/test_async_accumulator.py::test_max_threads[32-16]
PASSED tests/accumulator/test_async_accumulator.py::test_max_threads[5-5]
PASSED tests/accumulator/test_async_accumulator.py::test_max_threads[None-4]
PASSED tests/accumulator/test_async_accumulator.py::test_max_threads[0-0]
PASSED tests/accumulator/test_async_accumulator.py::test_max_threads[-5--5]
PASSED tests/accumulator/test_async_accumulator.py::test_server_info_file_path_handling
PASSED tests/accumulator/test_async_accumulator.py::test_init_kwargs_none_handling
PASSED tests/accumulator/test_async_accumulator.py::test_server_start_method_logging
PASSED tests/accumulator/test_async_accumulator_err.py::test_accumulate_partial_success
PASSED tests/accumulator/test_async_accumulator_shutdown.py::test_shutdown_event_on_consumer_cancelled_error
PASSED tests/accumulator/test_async_accumulator_shutdown.py::test_shutdown_event_on_consumer_base_exception
PASSED tests/accumulator/test_async_accumulator_shutdown.py::test_shutdown_event_on_producer_cancelled_error
PASSED tests/accumulator/test_async_accumulator_shutdown.py::test_shutdown_event_on_producer_base_exception
PASSED tests/accumulator/test_async_accumulator_shutdown.py::test_shutdown_event_on_result_queue_exception_message
PASSED tests/accumulator/test_datatypes.py::test_datum_err_event_time
PASSED tests/accumulator/test_datatypes.py::test_datum_err_watermark
PASSED tests/accumulator/test_datatypes.py::test_datum_properties
PASSED tests/accumulator/test_datatypes.py::test_datum_default_values
PASSED tests/accumulator/test_datatypes.py::test_interval_window_start
PASSED tests/accumulator/test_datatypes.py::test_interval_window_end
PASSED tests/accumulator/test_datatypes.py::test_keyed_window_create
PASSED tests/accumulator/test_datatypes.py::test_keyed_window_default_values
PASSED tests/accumulator/test_datatypes.py::test_keyed_window_window_property
PASSED tests/accumulator/test_datatypes.py::test_accumulator_result_create
PASSED tests/accumulator/test_datatypes.py::test_accumulator_result_update_watermark
PASSED tests/accumulator/test_datatypes.py::test_accumulator_result_update_watermark_invalid_type
PASSED tests/accumulator/test_datatypes.py::test_accumulator_request_create
PASSED tests/accumulator/test_datatypes.py::test_window_operation_enum_values
PASSED tests/accumulator/test_datatypes.py::test_message_create
PASSED tests/accumulator/test_datatypes.py::test_message_default_values
PASSED tests/accumulator/test_datatypes.py::test_message_to_drop
PASSED tests/accumulator/test_datatypes.py::test_message_none_values
PASSED tests/accumulator/test_datatypes.py::test_message_from_datum
PASSED tests/accumulator/test_datatypes.py::test_message_from_datum_minimal
PASSED tests/accumulator/test_datatypes.py::test_message_from_datum_empty_keys
PASSED tests/accumulator/test_datatypes.py::test_accumulator_class_init
PASSED tests/accumulator/test_datatypes.py::test_accumulator_class_callable
PASSED tests/batchmap/test_async_batch_map.py::test_batch_map
PASSED tests/batchmap/test_async_batch_map.py::test_is_ready
PASSED tests/batchmap/test_async_batch_map.py::test_max_threads[32-16]
PASSED tests/batchmap/test_async_batch_map.py::test_max_threads[5-5]
PASSED tests/batchmap/test_async_batch_map.py::test_max_threads[None-4]
PASSED tests/batchmap/test_async_batch_map_err.py::test_batch_map_error
PASSED tests/batchmap/test_async_batch_map_err.py::test_batch_map_error_no_handshake
PASSED tests/batchmap/test_async_batch_map_err.py::test_invalid_input
PASSED tests/batchmap/test_async_batch_map_shutdown.py::test_shutdown_on_cancelled_error
PASSED tests/batchmap/test_async_batch_map_shutdown.py::test_shutdown_on_handler_error
PASSED tests/batchmap/test_datatypes.py::test_datum_err_event_time
PASSED tests/batchmap/test_datatypes.py::test_datum_err_watermark
PASSED tests/batchmap/test_datatypes.py::test_datum_value
PASSED tests/batchmap/test_datatypes.py::test_datum_key
PASSED tests/batchmap/test_datatypes.py::test_datum_event_time
PASSED tests/batchmap/test_datatypes.py::test_datum_watermark
PASSED tests/batchmap/test_datatypes.py::test_datum_id
PASSED tests/batchmap/test_messages.py::test_batch_responses_init
PASSED tests/batchmap/test_messages.py::test_batch_response_init
PASSED tests/batchmap/test_messages.py::test_batch_response_invalid_input
PASSED tests/batchmap/test_messages.py::test_batch_response_append
PASSED tests/batchmap/test_messages.py::test_batch_response_items
PASSED tests/batchmap/test_messages.py::test_message_key
PASSED tests/batchmap/test_messages.py::test_message_value
PASSED tests/batchmap/test_messages.py::test_message_to_all
PASSED tests/batchmap/test_messages.py::test_message_to_drop
PASSED tests/batchmap/test_messages.py::test_message_to
PASSED tests/errors/test_dtypes.py::test_runtime_error_entry_initialization
PASSED tests/errors/test_dtypes.py::test_runtime_error_entry_to_dict
PASSED tests/errors/test_dtypes.py::test_runtime_error_entry_empty_values
PASSED tests/errors/test_persist_critical_error.py::test_writes_error_details_to_json_file
PASSED tests/errors/test_persist_critical_error.py::test_uses_default_error_code_if_none_provided
PASSED tests/errors/test_persist_critical_error.py::test_persist_critical_error_all_threads_fail
PASSED tests/map/test_async_map_shutdown.py::test_shutdown_on_cancelled_error
PASSED tests/map/test_async_map_shutdown.py::test_shutdown_on_handler_error
PASSED tests/map/test_async_map_shutdown.py::test_shutdown_on_handshake_error
PASSED tests/map/test_async_mapper.py::test_run_server
PASSED tests/map/test_async_mapper.py::test_map
PASSED tests/map/test_async_mapper.py::test_map_grpc_error_no_handshake
PASSED tests/map/test_async_mapper.py::test_map_grpc_error
PASSED tests/map/test_async_mapper.py::test_is_ready
PASSED tests/map/test_async_mapper.py::test_invalid_input
PASSED tests/map/test_async_mapper.py::test_max_threads[32-16]
PASSED tests/map/test_async_mapper.py::test_max_threads[5-5]
PASSED tests/map/test_async_mapper.py::test_max_threads[None-4]
PASSED tests/map/test_messages.py::test_message_key
PASSED tests/map/test_messages.py::test_message_value
PASSED tests/map/test_messages.py::test_message_to_all
PASSED tests/map/test_messages.py::test_message_to_drop
PASSED tests/map/test_messages.py::test_message_to
PASSED tests/map/test_messages.py::test_messages_items
PASSED tests/map/test_messages.py::test_messages_append
PASSED tests/map/test_messages.py::test_messages_forward_to_drop
PASSED tests/map/test_messages.py::test_messages_err
PASSED tests/map/test_messages.py::test_map_class_call
PASSED tests/map/test_multiproc_map_shutdown.py::test_shutdown_event_set_on_handler_error
PASSED tests/map/test_multiproc_map_shutdown.py::test_shutdown_event_set_on_handshake_error
PASSED tests/map/test_multiproc_map_shutdown.py::test_shutdown_event_set_on_stream_close_before_handshake
PASSED tests/map/test_multiproc_map_shutdown.py::test_shutdown_event_set_on_stream_close_mid_processing
PASSED tests/map/test_multiproc_mapper.py::test_process_count[3-3]
PASSED tests/map/test_multiproc_mapper.py::test_process_count[None-16]
PASSED tests/map/test_multiproc_mapper.py::test_process_count[100-32]
PASSED tests/map/test_multiproc_mapper.py::test_udf_map_error[False-MapFn: expected handshake as the first message]
PASSED tests/map/test_multiproc_mapper.py::test_udf_map_error[True-Something is fishy!]
PASSED tests/map/test_multiproc_mapper.py::test_is_ready
PASSED tests/map/test_multiproc_mapper.py::test_map_forward_message
PASSED tests/map/test_multiproc_mapper.py::test_invalid_input
PASSED tests/map/test_sync_map_shutdown.py::test_shutdown_event_set_on_handler_error
PASSED tests/map/test_sync_map_shutdown.py::test_shutdown_event_set_on_handshake_error
PASSED tests/map/test_sync_map_shutdown.py::test_shutdown_event_set_on_stream_close_before_handshake
PASSED tests/map/test_sync_map_shutdown.py::test_shutdown_event_set_on_stream_close_mid_processing
PASSED tests/map/test_sync_mapper.py::test_init_with_args
PASSED tests/map/test_sync_mapper.py::test_udf_map_error[False-MapFn: expected handshake as the first message]
PASSED tests/map/test_sync_mapper.py::test_udf_map_error[True-Something is fishy!]
PASSED tests/map/test_sync_mapper.py::test_is_ready
PASSED tests/map/test_sync_mapper.py::test_map_forward_message
PASSED tests/map/test_sync_mapper.py::test_invalid_input
PASSED tests/map/test_sync_mapper.py::test_max_threads[32-16]
PASSED tests/map/test_sync_mapper.py::test_max_threads[5-5]
PASSED tests/map/test_sync_mapper.py::test_max_threads[None-4]
PASSED tests/mapstream/test_async_map_stream.py::test_map_stream
PASSED tests/mapstream/test_async_map_stream.py::test_is_ready
PASSED tests/mapstream/test_async_map_stream.py::test_max_threads[32-16]
PASSED tests/mapstream/test_async_map_stream.py::test_max_threads[5-5]
PASSED tests/mapstream/test_async_map_stream.py::test_max_threads[None-4]
PASSED tests/mapstream/test_async_map_stream_err.py::test_map_stream_error
PASSED tests/mapstream/test_async_map_stream_err.py::test_map_stream_error_no_handshake
PASSED tests/mapstream/test_async_map_stream_err.py::test_invalid_input
PASSED tests/mapstream/test_async_map_stream_shutdown.py::test_shutdown_on_cancelled_error
PASSED tests/mapstream/test_async_map_stream_shutdown.py::test_shutdown_on_handler_error
PASSED tests/mapstream/test_messages.py::test_message_key
PASSED tests/mapstream/test_messages.py::test_message_value
PASSED tests/mapstream/test_messages.py::test_message_to_all
PASSED tests/mapstream/test_messages.py::test_message_to_drop
PASSED tests/mapstream/test_messages.py::test_message_to
PASSED tests/mapstream/test_messages.py::test_messages_items
PASSED tests/mapstream/test_messages.py::test_messages_append
PASSED tests/mapstream/test_messages.py::test_messages_forward_to_drop
PASSED tests/mapstream/test_messages.py::test_messages_err
PASSED tests/reduce/test_async_reduce.py::test_reduce
PASSED tests/reduce/test_async_reduce.py::test_reduce_with_multiple_keys
PASSED tests/reduce/test_async_reduce.py::test_is_ready
PASSED tests/reduce/test_async_reduce.py::test_error_init
PASSED tests/reduce/test_async_reduce.py::test_max_threads[32-16]
PASSED tests/reduce/test_async_reduce.py::test_max_threads[5-5]
PASSED tests/reduce/test_async_reduce.py::test_max_threads[None-4]
PASSED tests/reduce/test_async_reduce_err.py::test_reduce
PASSED tests/reduce/test_async_reduce_err.py::test_reduce_window_len
PASSED tests/reduce/test_async_reduce_shutdown.py::test_shutdown_on_cancelled_error
PASSED tests/reduce/test_async_reduce_shutdown.py::test_shutdown_on_handler_error
PASSED tests/reduce/test_datatypes.py::test_datum_err_event_time
PASSED tests/reduce/test_datatypes.py::test_datum_err_watermark
PASSED tests/reduce/test_datatypes.py::test_datum_value
PASSED tests/reduce/test_datatypes.py::test_datum_key
PASSED tests/reduce/test_datatypes.py::test_datum_event_time
PASSED tests/reduce/test_datatypes.py::test_datum_watermark
PASSED tests/reduce/test_datatypes.py::test_interval_window_start
PASSED tests/reduce/test_datatypes.py::test_interval_window_end
PASSED tests/reduce/test_datatypes.py::test_metadata_interval_window
PASSED tests/reduce/test_datatypes.py::test_reduce_window_create
PASSED tests/reduce/test_datatypes.py::test_reducer_class_init
PASSED tests/reduce/test_datatypes.py::test_reducer_class_deep_copy
PASSED tests/reduce/test_messages.py::test_message_key
PASSED tests/reduce/test_messages.py::test_message_value
PASSED tests/reduce/test_messages.py::test_message_to_all
PASSED tests/reduce/test_messages.py::test_message_to_drop
PASSED tests/reduce/test_messages.py::test_message_to
PASSED tests/reduce/test_messages.py::test_messages_items
PASSED tests/reduce/test_messages.py::test_messages_append
PASSED tests/reduce/test_messages.py::test_messages_forward_to_drop
PASSED tests/reduce/test_messages.py::test_messages_err
PASSED tests/reducestreamer/test_async_reduce.py::test_reduce
PASSED tests/reducestreamer/test_async_reduce.py::test_reduce_with_multiple_keys
PASSED tests/reducestreamer/test_async_reduce.py::test_is_ready
PASSED tests/reducestreamer/test_async_reduce.py::test_error_init
PASSED tests/reducestreamer/test_async_reduce.py::test_max_threads[32-16]
PASSED tests/reducestreamer/test_async_reduce.py::test_max_threads[5-5]
PASSED tests/reducestreamer/test_async_reduce.py::test_max_threads[None-4]
PASSED tests/reducestreamer/test_async_reduce.py::test_start_shutdown_handler_without_callback
PASSED tests/reducestreamer/test_async_reduce.py::test_start_shutdown_handler_with_callback
PASSED tests/reducestreamer/test_async_reduce.py::test_start_exits_on_error
PASSED tests/reducestreamer/test_async_reduce_err.py::test_reduce
PASSED tests/reducestreamer/test_async_reduce_err.py::test_reduce_window_len
PASSED tests/reducestreamer/test_async_reduce_err.py::test_cancelled_error_in_consumer_loop
PASSED tests/reducestreamer/test_async_reduce_err.py::test_base_exception_in_consumer_loop
PASSED tests/reducestreamer/test_async_reduce_err.py::test_cancelled_error_awaiting_producer
PASSED tests/reducestreamer/test_async_reduce_err.py::test_base_exception_awaiting_producer
PASSED tests/reducestreamer/test_async_reduce_err.py::test_cancel_and_await_remaining_tasks_on_post_processing_error
PASSED tests/reducestreamer/test_async_reduce_err.py::test_cancel_and_await_with_already_done_futures
PASSED tests/reducestreamer/test_datatypes.py::test_err_event_time
PASSED tests/reducestreamer/test_datatypes.py::test_err_watermark
PASSED tests/reducestreamer/test_datatypes.py::test_datum_value
PASSED tests/reducestreamer/test_datatypes.py::test_datum_key
PASSED tests/reducestreamer/test_datatypes.py::test_datum_event_time
PASSED tests/reducestreamer/test_datatypes.py::test_datum_watermark
PASSED tests/reducestreamer/test_datatypes.py::test_interval_window_start
PASSED tests/reducestreamer/test_datatypes.py::test_interval_window_end
PASSED tests/reducestreamer/test_datatypes.py::test_metadata_interval_window
PASSED tests/reducestreamer/test_datatypes.py::test_create_window
PASSED tests/reducestreamer/test_datatypes.py::test_reducer_init
PASSED tests/reducestreamer/test_datatypes.py::test_reducer_deep_copy
PASSED tests/reducestreamer/test_messages.py::test_key
PASSED tests/reducestreamer/test_messages.py::test_value
PASSED tests/reducestreamer/test_messages.py::test_message_to_all
PASSED tests/reducestreamer/test_messages.py::test_message_to_drop
PASSED tests/reducestreamer/test_messages.py::test_message_to
PASSED tests/sideinput/test_responses.py::test_broadcast_message
PASSED tests/sideinput/test_responses.py::test_no_broadcast_message
PASSED tests/sideinput/test_responses.py::test_side_input_class_call
PASSED tests/sideinput/test_shutdown.py::test_shutdown_event_set_on_handler_error
PASSED tests/sideinput/test_shutdown.py::test_shutdown_event_not_set_on_success
PASSED tests/sideinput/test_side_input_server.py::test_init_with_args
PASSED tests/sideinput/test_side_input_server.py::test_side_input_err
PASSED tests/sideinput/test_side_input_server.py::test_is_ready
PASSED tests/sideinput/test_side_input_server.py::test_side_input_message
PASSED tests/sideinput/test_side_input_server.py::test_side_input_no_broadcast
PASSED tests/sideinput/test_side_input_server.py::test_invalid_input
PASSED tests/sideinput/test_side_input_server.py::test_max_threads[32-16]
PASSED tests/sideinput/test_side_input_server.py::test_max_threads[5-5]
PASSED tests/sideinput/test_side_input_server.py::test_max_threads[None-4]
PASSED tests/sink/test_async_sink.py::test_run_server
PASSED tests/sink/test_async_sink.py::test_sink
PASSED tests/sink/test_async_sink.py::test_sink_err
PASSED tests/sink/test_async_sink.py::test_sink_err_handshake
PASSED tests/sink/test_async_sink.py::test_sink_fallback
PASSED tests/sink/test_async_sink.py::test_sink_on_success1
PASSED tests/sink/test_async_sink.py::test_sink_on_success2
PASSED tests/sink/test_async_sink.py::test_invalid_server_type
PASSED tests/sink/test_async_sink.py::test_start_fallback_sink
PASSED tests/sink/test_async_sink.py::test_start_on_success_sink
PASSED tests/sink/test_async_sink.py::test_max_threads[32-16]
PASSED tests/sink/test_async_sink.py::test_max_threads[5-5]
PASSED tests/sink/test_async_sink.py::test_max_threads[None-4]
PASSED tests/sink/test_async_sink_shutdown.py::test_shutdown_on_cancelled_error
PASSED tests/sink/test_async_sink_shutdown.py::test_shutdown_on_handler_error
PASSED tests/sink/test_datatypes.py::test_err_event_time
PASSED tests/sink/test_datatypes.py::test_err_watermark
PASSED tests/sink/test_datatypes.py::test_value
PASSED tests/sink/test_datatypes.py::test_id
PASSED tests/sink/test_datatypes.py::test_event_time
PASSED tests/sink/test_datatypes.py::test_watermark
PASSED tests/sink/test_responses.py::test_as_success
PASSED tests/sink/test_responses.py::test_as_failure
PASSED tests/sink/test_responses.py::test_as_fallback
PASSED tests/sink/test_responses.py::test_as_on_success
PASSED tests/sink/test_responses.py::test_responses
PASSED tests/sink/test_responses.py::test_sink_class_call
PASSED tests/sink/test_server.py::test_is_ready
PASSED tests/sink/test_server.py::test_udsink_err_handshake
PASSED tests/sink/test_server.py::test_udsink_err
PASSED tests/sink/test_server.py::test_forward_message
PASSED tests/sink/test_server.py::test_invalid_init
PASSED tests/sink/test_server.py::test_start_fallback_sink
PASSED tests/sink/test_server.py::test_start_on_success_sink
PASSED tests/sink/test_server.py::test_max_threads[32-16]
PASSED tests/sink/test_server.py::test_max_threads[5-5]
PASSED tests/sink/test_server.py::test_max_threads[None-4]
PASSED tests/sink/test_server.py::test_shutdown_event_set_on_handler_error
PASSED tests/sink/test_server.py::test_shutdown_event_set_on_handshake_error
PASSED tests/sink/test_server.py::test_shutdown_event_set_on_stream_close_before_handshake
PASSED tests/sink/test_server.py::test_shutdown_event_set_on_stream_close_mid_batch
PASSED tests/source/test_async_source.py::test_read_source
PASSED tests/source/test_async_source.py::test_is_ready
PASSED tests/source/test_async_source.py::test_ack
PASSED tests/source/test_async_source.py::test_nack
PASSED tests/source/test_async_source.py::test_pending
PASSED tests/source/test_async_source.py::test_partitions
PASSED tests/source/test_async_source.py::test_max_threads[32-16]
PASSED tests/source/test_async_source.py::test_max_threads[5-5]
PASSED tests/source/test_async_source.py::test_max_threads[None-4]
PASSED tests/source/test_async_source_err.py::test_read_error
PASSED tests/source/test_async_source_err.py::test_read_handshake_error
PASSED tests/source/test_async_source_err.py::test_ack_error
PASSED tests/source/test_async_source_err.py::test_nack_error
PASSED tests/source/test_async_source_err.py::test_ack_no_handshake_error
PASSED tests/source/test_async_source_err.py::test_pending_error
PASSED tests/source/test_async_source_err.py::test_partition_error
PASSED tests/source/test_async_source_err.py::test_invalid_server_type
PASSED tests/source/test_async_source_shutdown.py::test_shutdown_on_read_cancelled_error
PASSED tests/source/test_async_source_shutdown.py::test_shutdown_on_ack_cancelled_error
PASSED tests/source/test_async_source_shutdown.py::test_shutdown_on_nack_cancelled_error
PASSED tests/source/test_async_source_shutdown.py::test_shutdown_on_pending_cancelled_error
PASSED tests/source/test_async_source_shutdown.py::test_shutdown_on_partitions_cancelled_error
PASSED tests/source/test_message.py::test_message_creation
PASSED tests/source/test_message.py::test_offset_creation
PASSED tests/source/test_message.py::test_default_offset_creation
PASSED tests/source/test_message.py::test_datum_creation
PASSED tests/source/test_message.py::test_err_num_record
PASSED tests/source/test_message.py::test_err_timeout
PASSED tests/source/test_message.py::test_partition_response
PASSED tests/source/test_message.py::test_err_partition
PASSED tests/sourcetransform/test_async.py::test_run_server
PASSED tests/sourcetransform/test_async.py::test_async_source_transformer
PASSED tests/sourcetransform/test_async.py::test_async_source_transformer_grpc_error_no_handshake
PASSED tests/sourcetransform/test_async.py::test_async_source_transformer_grpc_error
PASSED tests/sourcetransform/test_async.py::test_is_ready
PASSED tests/sourcetransform/test_async.py::test_invalid_input
PASSED tests/sourcetransform/test_async.py::test_max_threads[32-16]
PASSED tests/sourcetransform/test_async.py::test_max_threads[5-5]
PASSED tests/sourcetransform/test_async.py::test_max_threads[None-4]
PASSED tests/sourcetransform/test_async.py::test_source_transformer_with_metadata
PASSED tests/sourcetransform/test_async_shutdown.py::test_shutdown_on_cancelled_error
PASSED tests/sourcetransform/test_async_shutdown.py::test_shutdown_on_handler_error
PASSED tests/sourcetransform/test_messages.py::test_message_creation
PASSED tests/sourcetransform/test_messages.py::test_message_to_drop
PASSED tests/sourcetransform/test_messages.py::test_message_with_user_metadata
PASSED tests/sourcetransform/test_messages.py::test_message_default_user_metadata
PASSED tests/sourcetransform/test_messages.py::test_messages_items
PASSED tests/sourcetransform/test_messages.py::test_messages_append
PASSED tests/sourcetransform/test_messages.py::test_messages_err
PASSED tests/sourcetransform/test_messages.py::test_datum_with_metadata
PASSED tests/sourcetransform/test_messages.py::test_datum_default_metadata
PASSED tests/sourcetransform/test_messages.py::test_source_transform_class_call
PASSED tests/sourcetransform/test_multiproc.py::test_multiproc_init
PASSED tests/sourcetransform/test_multiproc.py::test_multiproc_process_count
PASSED tests/sourcetransform/test_multiproc.py::test_max_process_count
PASSED tests/sourcetransform/test_multiproc.py::test_udf_mapt_error[True-Something is fishy]
PASSED tests/sourcetransform/test_multiproc.py::test_udf_mapt_error[False-SourceTransformFn: expected handshake message]
PASSED tests/sourcetransform/test_multiproc.py::test_is_ready
PASSED tests/sourcetransform/test_multiproc.py::test_mapt_assign_new_event_time
PASSED tests/sourcetransform/test_multiproc.py::test_invalid_input
PASSED tests/sourcetransform/test_multiproc.py::test_max_threads[32-16]
PASSED tests/sourcetransform/test_multiproc.py::test_max_threads[5-5]
PASSED tests/sourcetransform/test_multiproc.py::test_max_threads[None-4]
PASSED tests/sourcetransform/test_multiproc_shutdown.py::test_shutdown_event_set_on_handler_error
PASSED tests/sourcetransform/test_multiproc_shutdown.py::test_shutdown_event_set_on_handshake_error
PASSED tests/sourcetransform/test_multiproc_shutdown.py::test_shutdown_event_set_on_stream_close_before_handshake
PASSED tests/sourcetransform/test_multiproc_shutdown.py::test_shutdown_event_set_on_stream_close_mid_processing
PASSED tests/sourcetransform/test_sync_server.py::test_init_with_args
PASSED tests/sourcetransform/test_sync_server.py::test_udf_mapt_error[True-Something is fishy]
PASSED tests/sourcetransform/test_sync_server.py::test_udf_mapt_error[False-SourceTransformFn: expected handshake message]
PASSED tests/sourcetransform/test_sync_server.py::test_is_ready
PASSED tests/sourcetransform/test_sync_server.py::test_mapt_assign_new_event_time
PASSED tests/sourcetransform/test_sync_server.py::test_invalid_input
PASSED tests/sourcetransform/test_sync_server.py::test_max_threads[32-16]
PASSED tests/sourcetransform/test_sync_server.py::test_max_threads[5-5]
PASSED tests/sourcetransform/test_sync_server.py::test_max_threads[None-4]
PASSED tests/sourcetransform/test_sync_server.py::test_source_transform_with_metadata
PASSED tests/sourcetransform/test_sync_shutdown.py::test_shutdown_event_set_on_handler_error
PASSED tests/sourcetransform/test_sync_shutdown.py::test_shutdown_event_set_on_handshake_error
PASSED tests/sourcetransform/test_sync_shutdown.py::test_shutdown_event_set_on_stream_close_before_handshake
PASSED tests/sourcetransform/test_sync_shutdown.py::test_shutdown_event_set_on_stream_close_mid_processing
PASSED tests/test_info_server.py::test_empty_write_info
PASSED tests/test_info_server.py::test_success_write_info
PASSED tests/test_info_server.py::test_metadata_env
PASSED tests/test_info_server.py::test_invalid_input
PASSED tests/test_info_server.py::test_file_new
PASSED tests/test_metadata.py::TestSystemMetadata::test_empty_system_metadata
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_groups
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_keys_existing_group
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_keys_nonexistent_group
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_value_existing
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_value_nonexistent_group
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_value_nonexistent_key
PASSED tests/test_metadata.py::TestSystemMetadata::test_system_metadata_value_nonexistent_both
PASSED tests/test_metadata.py::TestUserMetadata::test_empty_user_metadata
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_groups
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_keys_existing_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_keys_nonexistent_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_contains
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_getitem_existing
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_getitem_nonexistent_raises_keyerror
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_setitem
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_setitem_overwrite
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_delitem_existing
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_delitem_nonexistent_raises_keyerror
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_len
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_value_existing
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_value_nonexistent_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_value_nonexistent_key
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_value_nonexistent_both
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_add_new_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_add_to_existing_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_add_overwrites_existing_key
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_existing_key
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_last_key_removes_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_nonexistent_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_nonexistent_key
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_nonexistent_key_single_key_group
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_nonexistent_both
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_group_existing
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_remove_group_nonexistent
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_clear
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_clear_empty
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_to_proto
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_to_proto_empty
PASSED tests/test_metadata.py::TestUserMetadata::test_user_metadata_complex_scenario
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_empty_group_name
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_empty_key_name
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_empty_value
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_multiple_groups_with_same_keys
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_special_characters_in_names
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_large_values
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_many_groups
PASSED tests/test_metadata.py::TestUserMetadataEdgeCases::test_many_keys_in_group
PASSED tests/test_validate.py::TestValidateMessageFields::test_invalid_value_type_raises
PASSED tests/test_validate.py::TestValidateMessageFields::test_invalid_keys_type_raises
PASSED tests/test_validate.py::TestValidateMessageFields::test_invalid_keys_element_type_raises
PASSED tests/test_validate.py::TestValidateMessageFields::test_invalid_tags_type_raises
PASSED tests/test_validate.py::TestValidateMessageFields::test_invalid_tags_element_type_raises
PASSED tests/test_validate.py::TestValidateMessageFields::test_valid_inputs_no_error
PASSED tests/test_validate.py::TestValidateMessageFields::test_all_none_no_error
```

</details>
